### PR TITLE
fix(swift5): Add cocoapods installation notice in README

### DIFF
--- a/templates/swift5/README.mustache
+++ b/templates/swift5/README.mustache
@@ -47,6 +47,7 @@ Run `carthage update`
 
 ### CocoaPods
 
+Add `pod ‘{{projectName}}’, '{{podVersion}}'` in your `Podfile`
 Run `pod install`
 
 {{/useVapor}}## Code sample


### PR DESCRIPTION
Add cocoapods installation notice in README for iOS API client and iOS video uploader.