### PR TITLE
fix(swift5): add missing link to Carthage repo

### DIFF
--- a/templates/swift5/README.mustache
+++ b/templates/swift5/README.mustache
@@ -43,6 +43,12 @@ Add the following entry in your Package.swift:
 {{^useVapor}}
 ### Carthage
 
+Specify it in your `Cartfile`:
+
+```
+github "apivideo/{{gitRepoId}}" ~> {{podVersion}}
+```
+
 Run `carthage update`
 
 ### CocoaPods


### PR DESCRIPTION
Add missing link to Carthage repo
