### PR TITLE
fix(oas): add missing linkActive field in player upload/create payload

### DIFF
--- a/config/nodejs.yaml
+++ b/config/nodejs.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 2.2.2 (2022-02-08):
+      - Add missing `linkActive` in `PlayerThemeUpdatePayload` and `PlayerThemeCreationPayload`
   - 2.2.1 (2022-01-24):
       - Add applicationName parameter (to allow user agent extension)
   - 2.2.0 (2022-01-07):

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -6077,6 +6077,9 @@ components:
           description: >-
             RGBA color for all controls when hovered. Default: rgba(255, 255,
             255, 1)
+        linkActive:
+          type: string
+          description: 'RGBA color for the play button when hovered.'
         trackPlayed:
           type: string
           description: >-
@@ -6129,9 +6132,6 @@ components:
           description: 'When the player was last updated, presented in ISO-8601 format.'
           format: date-time
           example: '2020-01-31T10:18:47+00:00'
-        linkActive:
-          type: string
-          description: 'RGBA color for the play button when hovered.'
         assets:
           type: object
           properties:
@@ -6165,6 +6165,9 @@ components:
           description: >-
             RGBA color for all controls when hovered. Default: rgba(255, 255,
             255, 1)
+        linkActive:
+          type: string
+          description: 'RGBA color for the play button when hovered.'
         trackPlayed:
           type: string
           description: >-
@@ -6254,6 +6257,9 @@ components:
           description: >-
             RGBA color for all controls when hovered. Default: rgba(255, 255,
             255, 1)
+        linkActive:
+          type: string
+          description: 'RGBA color for the play button when hovered.'
         trackPlayed:
           type: string
           description: >-

--- a/templates/nodejs/test/sandbox.spec.ts.mustache
+++ b/templates/nodejs/test/sandbox.spec.ts.mustache
@@ -218,6 +218,7 @@ describe('ApiVideoClient', () => {
       text: 'rgba(255, 255, 255, .95)',
       link: 'rgba(255, 0, 0, .95)',
       linkHover: 'rgba(255, 255, 255, .75)',
+      linkActive: 'rgba(255, 0, 0, .75)',
       trackPlayed: 'rgba(255, 255, 255, .95)',
       trackUnplayed: 'rgba(255, 255, 255, .1)',
       trackBackground: 'rgba(0, 0, 0, 0)',


### PR DESCRIPTION
Fix player bug - the “Link active color” doesn’t save