### PR TITLE
fix(swift5): fix model example in documentation

### DIFF
--- a/apivideo-generator/src/main/java/video/api/client/generator/Swift5.java
+++ b/apivideo-generator/src/main/java/video/api/client/generator/Swift5.java
@@ -128,4 +128,17 @@ public class Swift5 extends Swift5ClientCodegen {
         }
         return super.constructExampleCode(codegenParameter, modelMaps, visitedModels);
     }
+
+    @Override
+    public String constructExampleCode(CodegenModel codegenModel, HashMap<String, CodegenModel> modelMaps, Set<String> visitedModels) {
+        String example;
+        example = codegenModel.classname + "(";
+        List<String> propertyExamples = new ArrayList<>();
+        for (CodegenProperty codegenProperty : codegenModel.vars) {
+            propertyExamples.add(codegenProperty.name + ": " + constructExampleCode(codegenProperty, modelMaps, visitedModels));
+        }
+        example += StringUtils.join(propertyExamples, ", ");
+        example += ")";
+        return example;
+    }
 }


### PR DESCRIPTION
In example such as https://github.com/apivideo/api.video-ios-client/blob/main/docs/LiveStreamsAPI.md#example

The object class should be`LiveStreamCreationPayload` and not `live-stream-creation-payload`.
Example
```
let liveStreamCreationPayload = live-stream-creation-payload(name: "name_example", record: true, _public: false, playerId: "playerId_example") // LiveStreamCreationPayload | 
```