### PR TITLE
Fix code snippet tab includes

### DIFF
--- a/templates/documentation/vod/list-videos-2.md
+++ b/templates/documentation/vod/list-videos-2.md
@@ -53,7 +53,7 @@ Using Nuget
 Install-Package ApiVideo
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
+{% include "_partials/code-tabs.html" samples: content %}
 
 ## List all videos
 
@@ -148,7 +148,7 @@ videos = videos_api.list()
 print(videos)
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
+{% include "_partials/code-tabs.html" samples: content %}
 
 ## List videos using query parameters
 
@@ -262,7 +262,7 @@ videos = videos_api.list(title='your title')
 print(videos)
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
+{% include "_partials/code-tabs.html" samples: content %}
 
 ## See a list of videos in the dashboard
 


### PR DESCRIPTION
This change is for [this Asana task](https://app.asana.com/0/1204577546714196/1205364682863051).

Summary: I updated the referenced file names (code-tab.html) and the content tags in the include functions. The affected page is `VOD/list-videos.md`.

This is also a test commit for the new repo :) 