### PR TITLE
Bugfix: multitab code snippets

### DIFF
--- a/templates/documentation/get-started/create-and-manage-tokens-for-delegated-uploads.md
+++ b/templates/documentation/get-started/create-and-manage-tokens-for-delegated-uploads.md
@@ -37,6 +37,8 @@ The clients offered by api.video include:
 
 To install your selected client, do the following: 
 
+{% capture samples %}
+
 ```go
 go get github.com/apivideo/api.video-go-client
 ```
@@ -59,6 +61,9 @@ Using Nuget
 Install-Package ApiVideo
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
+
 ## Retrieve your API key
 
 You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
@@ -71,6 +76,8 @@ You'll need your API key to get started. You can sign up for one here: [Get your
 ## Generate a token for delegated upload
 
 Use this code sample to generate a token for use with a delegated upload. You can include a TTL (time-to-live) if you like. The token will expire after exceeding the set TTL. If you don't send in a TTL, your token will last until you choose to delete it.
+
+{% capture samples %}
 
 ```curl
 curl --request POST \
@@ -174,11 +181,14 @@ response = tokens_api.create_token(token_creation_payload)
 print(response)
 ```
 
-
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## List all tokens you created
 
 If a token is compromised, or you want to see how many tokens you have, you will need to retrieve a list of them programmatically. Here is the code sample for that:
+
+{% capture samples %}
 
 ```curl
 curl --request GET \
@@ -281,11 +291,15 @@ response = tokens_api.list()
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Show details about a specific token
 
 Retrieve information about a specific token. To do this, you send a request containing the token ID for the token you need details about.
+
+{% capture samples %}
 
 ```curl
 curl --request GET \
@@ -384,11 +398,15 @@ response = tokens_api.get_token(token)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Delete a token
 
 If you create a token that's compromised, you may want to remove it. Or, you might want to clean up how many tokens you have in general. All you need to do to delete a token is send a request containing the token ID for the token you want to remove.
+
+{% capture samples %}
 
 ```curl
 curl --request DELETE \
@@ -493,6 +511,8 @@ response = videos_api.delete(videos[0]['video_id'])
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Conclusion

--- a/templates/documentation/get-started/upload-a-video-with-a-delegated-token.md
+++ b/templates/documentation/get-started/upload-a-video-with-a-delegated-token.md
@@ -40,6 +40,8 @@ The clients offered by api.video include:
 
 To install your selected client, do the following: 
 
+{% capture samples %}
+
 ```go
 go get github.com/apivideo/api.video-go-client
 ```
@@ -61,7 +63,8 @@ Using Nuget
   
 Install-Package ApiVideo
 ```
-
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Retrieve your API key
@@ -76,6 +79,8 @@ You'll need your API key to get started. You can sign up for one here: [Get your
 ## Delegated upload
 
 You must first create a token and get the unique token ID to do a delegated upload. Then, you include it in your request as a query parameter. In the body, you place the path to the file you want to upload. If you are uploading a file that's 200 MiB or larger, to do a progressive upload, you will need to break the file into smaller pieces (no smaller than 5 MiB). Then send a request containing the first piece of your upload. Subsequent pieces must be sent with the video ID included in the body along with the file chunk. Retrieve the video ID from the response that comes back after your first request to upload. 
+
+{% capture samples %}
 
 ```curl
 curl --request POST \
@@ -178,7 +183,8 @@ response = videos_api.upload_with_upload_token(token, file)
 print(response)
 © 2022 GitHub, Inc.
 ```
-
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Conclusion

--- a/templates/documentation/live-streaming/working-with-live-streams.md
+++ b/templates/documentation/live-streaming/working-with-live-streams.md
@@ -24,6 +24,8 @@ The clients offered by api.video include:
 
 To install your selected client, do the following: 
 
+{% capture samples %}
+
 ```go
 go get github.com/apivideo/api.video-go-client
 ```
@@ -46,6 +48,9 @@ Using Nuget
 Install-Package ApiVideo
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
+
 ## Retrieve your API key
 
 You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
@@ -58,6 +63,8 @@ You'll need your API key to get started. You can sign up for one here: [Get your
 ## Show live stream (retrieve details for watching)
 
 You can retrieve details about any live stream by sending a request containing the live stream ID. The response will show you the current state of the live stream and provide all the details you need if you want to broadcast using a particular live stream container. 
+
+{% capture samples %}
 
 ```curl
 curl --request GET \
@@ -153,6 +160,8 @@ live_stream_api = LiveStreamsApi(client)
 response = live_stream_api.get(live_stream_id)
 print(response)
 ```
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## Show live stream (retrieve details for watching) with your dashboard
 
@@ -178,6 +187,8 @@ If you want to update details for your live stream, you need the unique ID for y
 - playerId - You can associate an api.video player with your live stream by providing the player's ID.
 
 The code sample to update is: 
+
+{% capture samples %}
 
 ```curl
 curl --request PATCH \
@@ -275,6 +286,9 @@ response = live_stream_api.update(live_stream_id, live_stream_update_payload)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
+
 ## Update a live stream using the dashboard
 
 You can update live stream details from your dashboard if you don't want to retrieve details about a stream programmatically. Do the following:
@@ -294,6 +308,8 @@ You can update live stream details from your dashboard if you don't want to retr
 ## Delete a live stream
 
 You can delete a live stream by sending in a DELETE request using the unique ID for the live stream. The code sample looks like this:
+
+{% capture samples %}
 
 ```curl
 curl --request DELETE \
@@ -364,6 +380,9 @@ live_stream_api = LiveStreamsApi(client)
 response = live_stream_api.delete(live_stream)
 print(response)
 ```
+
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## Delete a live stream from your dashboard
 

--- a/templates/documentation/vod/creating-and-managing-chapters.md
+++ b/templates/documentation/vod/creating-and-managing-chapters.md
@@ -66,6 +66,8 @@ To upload chapters for your video, you'll need a .VTT file containing details ab
 - [Adding chapters to your videos](https://api.video/blog/tutorials/video-chapters)
 - [Video chapters: Using external buttons for controls](https://api.video/blog/tutorials/video-chapters) 
 
+{% capture content %}
+
 ```curl
 curl --request POST \
      --url https://ws.api.video/videos/vi4k0jvEUuaTdRAEjQ4Jfrgz/chapters/en \
@@ -171,6 +173,8 @@ response = chapter_api.upload(video_id, language, file)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" samples: content %}
 
 
 ## Upload a chapter using the dashboard
@@ -190,6 +194,8 @@ To upload a chapter, do the following:
 ## List chapters
 
 If you just want to list all the chapters that are available to you, you can send a request with the video ID for the video you want this information for. All chapters will be returned in the response.
+
+{% capture samples %}
 
 ```curl
 curl --request GET \
@@ -292,6 +298,8 @@ response = chapter_api.list(video_id)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" samples: content %}
 
 
 ## List chapters using the dashboard
@@ -310,6 +318,8 @@ To list all chapter files for a video, do the following:
 ## Show a chapter
 
 You can retrieve details about a specific chapters file by sending a request with the video ID for the video you want chapter information for, and the valid BCP 47 tag for the specific chapter file. 
+
+{% capture samples %}
 
 ```curl
 curl --request GET \
@@ -414,6 +424,9 @@ response = chapter_api.get(video_id, language)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
+
 
 
 ## Show a chapter file using the dashboard
@@ -430,6 +443,9 @@ To show a chapter file using the dashboard, do the following:
 ## Delete a chapter
 
 To delete a chapter, send the unique video ID with the chapters you want to delete. Include the appropriate BCP 47 language tag. You can only have one set of chapters per tag. Deletion is permanent, so be sure it's what you want to do.
+
+{% capture samples %}
+
 
 ```curl
 curl --request DELETE \
@@ -528,6 +544,8 @@ response = chapter_api.delete(video_id, language)
 print(response)
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Delete a chapter using the dashboard

--- a/templates/documentation/vod/list-videos-2.md
+++ b/templates/documentation/vod/list-videos-2.md
@@ -53,7 +53,7 @@ Using Nuget
 Install-Package ApiVideo
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.html" samples: content %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## List all videos
 
@@ -148,7 +148,7 @@ videos = videos_api.list()
 print(videos)
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.html" samples: content %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## List videos using query parameters
 
@@ -262,7 +262,7 @@ videos = videos_api.list(title='your title')
 print(videos)
 ```
 {% endcapture %}
-{% include "_partials/code-tabs.html" samples: content %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 ## See a list of videos in the dashboard
 

--- a/templates/documentation/vod/upload-a-video-regular-upload.md
+++ b/templates/documentation/vod/upload-a-video-regular-upload.md
@@ -54,6 +54,8 @@ The clients offered by api.video include:
 
 To install your selected client, do the following: 
 
+{% capture samples %}
+
 ```go
 go get github.com/apivideo/api.video-go-client
 ```
@@ -76,11 +78,15 @@ Using Nuget
 Install-Package ApiVideo
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Create a video container and upload a video
 
 When you want to upload a video using the regular way, your video must be under 200 MB. It's a two-step process. First, you create a video container with all your video details and metadata. Then, you retrieve the container's video ID and upload your video into the container using the ID. 
+
+{% capture samples %}
 
 ```curl
 curl --request POST \
@@ -308,11 +314,15 @@ namespace Example
 }
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Create a video container and upload a video over 200 MB with a progressive upload
 
 When you do a progressive upload for a video, it's because the video is too big to send in one request to api.video. To upload the entire video, it must be broken into chunks, and then each chunk is sent. The smallest chunk size allowed is 5 MiB. When you send using one of the clients, you must indicate when you send the last part. If you implement without a client, then when you send the last part, api.video can tell because your header will say Content-Range: part 3/3 (or whatever number of chunks you sent - 4/4, 8/8, etc.) 
+
+{% capture samples %}
 
 ```curl
 curl --request POST \
@@ -329,7 +339,7 @@ curl --request POST \
 }
 '
 
-------Retrieve the access_token from the response, then include in your next request.-----
+# Retrieve the access_token from the response, then include in your next request.
 
 curl --request POST \
      --url https://ws.api.video/videos//source \
@@ -338,8 +348,7 @@ curl --request POST \
      --header 'Content-Range: part%201%2F3' \
      --header 'Content-Type: multipart/form-data'
 
-------You would send each part until the last part is sent. In order to do this with
- a cURL request, you must break your video into chunks ahead of time.------
+# You would send each part until the last part is sent. In order to do this with a cURL request, you must break your video into chunks ahead of time.
 ```
 ```go
 package main
@@ -498,6 +507,8 @@ def upload(file):
 upload('VIDEO_FILE.mp4')
 ```
 
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
 
 
 ## Create a video container and upload a video over 200 MiB with bytes in the content-range header
@@ -508,13 +519,15 @@ Content-Range: bytes 0-5242879
 
 And then continue from there. By default, the api.video clients handle uploads for you using this method. If you want to try it yourself without the client, the sample will look like this in cURL: 
 
+{% capture samples %}
+
 ```curl
 curl -X POST \
   https://sandbox.api.video/auth/api-key \
   -H 'Content-Type: application/json' \
   -d '{"apiKey": "your_api_key"}'
   
-------Retrieve the access_token from the response, then include in your next request.-----
+# Retrieve the access_token from the response, then include in your next request.
 
 curl -X POST https://sandbox.api.video/videos \
   -H 'Content-Type: application/json' \
@@ -525,17 +538,17 @@ curl -X POST https://sandbox.api.video/videos \
     "source":"https://example.com/myVideo.mp4"
   }'
   
-------Split your video into chunks, if you're on a mac you can use this command-----
+# Split your video into chunks, if you're on a mac you can use this command
   
 split -b 100m source.mp4.mp4 file_chunk_
 
-------Split your video into chunks, if you're using Linux you can use this command-----
+# Split your video into chunks, if you're using Linux you can use this command
 
 /path/to/source.mp4` is a 289MB (`281905832 B`) file .
 
 split --bytes=100M source.mp4 file_chunk_
 
---You'll need to send a cURL request for each chunk, with the proper Content-Range header--
+# You'll need to send a cURL request for each chunk, with the proper Content-Range header
 
 curl https://sandbox.api.video/videos/vitq4gOj8GyDT9kyxPQoyNJl/source \
   -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImFiYjcxNmNiY2ZiNmY4MDc2OWEzZmQ1MjlhMjZiZWRkY2EwMzhlYzA3NDk5M2ZiMTA0YjhiZGMwOTI5MzgxN2M3NmNkNzI4ZDIzOGMzZmNlIn0.eyJhdWQiOiJsaWJjYXN0IiwianRpIjoiYWJiNzE2Y2JjZmI2ZjgwNzY5YTNmZDUyOWEyNmJlZGRjYTAzOGVjMDc0OTkzZmIxMDRiOGJkYzA5MjkzODE3Yzc2Y2Q3MjhkMjM4YzNmY2UiLCJpYXQiOjE1MjY1NDgzMDEsIm5iZiI6MTUyNjU0ODMwMSwiZXhwIjoxNTI2NTUxOTAxLCJzdWIiOiJ1c01vbml0b3IiLCJzY29wZXMiOlsibW9uaXRvci5saWJjYXN0LmNvbSJdLCJjb250ZXh0Ijp7InVzZXIiOiJ1c01vbml0b3IiLCJwcm9qZWN0IjoicHJNb25pdG9yIiwibWVtYmVyIjoibWVNb25pdG9yIn19.jWHC18iEur69FzD5dm78wAwNzh2cPKTRvKuspyQNQKPvhEbYa2v4XhqVNh0TTw8JeNxBtcePBTMHl4S9nWsw7pW4KD8zbqzUjCZNYlaYDpu8vu_tmWVO2JccglJIjuQEaiTbkUsfLdgtsb_9DJ3frk1-WgAKuzu0HewhcGb80xivdJPqNYA6I1Ig8GOief9LTUNNJoqqZn1A1-UiGRTXDag7_yODuxzpMFaAzbaisfK0gYti-PnjyHGWhpGwRplMKPPJk6rSAp1d9TWWXVgg-bNqUzz4_sr33ICJTx7_qZzfamMqk5PDZbHOwpIj8L2DBfo3isvt6QliWmgFEOuvog' \
@@ -551,11 +564,17 @@ curl https://sandbox.api.video/videos/vitq4gOj8GyDT9kyxPQoyNJl/source \
   -H 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImFiYjcxNmNiY2ZiNmY4MDc2OWEzZmQ1MjlhMjZiZWRkY2EwMzhlYzA3NDk5M2ZiMTA0YjhiZGMwOTI5MzgxN2M3NmNkNzI4ZDIzOGMzZmNlIn0.eyJhdWQiOiJsaWJjYXN0IiwianRpIjoiYWJiNzE2Y2JjZmI2ZjgwNzY5YTNmZDUyOWEyNmJlZGRjYTAzOGVjMDc0OTkzZmIxMDRiOGJkYzA5MjkzODE3Yzc2Y2Q3MjhkMjM4YzNmY2UiLCJpYXQiOjE1MjY1NDgzMDEsIm5iZiI6MTUyNjU0ODMwMSwiZXhwIjoxNTI2NTUxOTAxLCJzdWIiOiJ1c01vbml0b3IiLCJzY29wZXMiOlsibW9uaXRvci5saWJjYXN0LmNvbSJdLCJjb250ZXh0Ijp7InVzZXIiOiJ1c01vbml0b3IiLCJwcm9qZWN0IjoicHJNb25pdG9yIiwibWVtYmVyIjoibWVNb25pdG9yIn19.jWHC18iEur69FzD5dm78wAwNzh2cPKTRvKuspyQNQKPvhEbYa2v4XhqVNh0TTw8JeNxBtcePBTMHl4S9nWsw7pW4KD8zbqzUjCZNYlaYDpu8vu_tmWVO2JccglJIjuQEaiTbkUsfLdgtsb_9DJ3frk1-WgAKuzu0HewhcGb80xivdJPqNYA6I1Ig8GOief9LTUNNJoqqZn1A1-UiGRTXDag7_yODuxzpMFaAzbaisfK0gYti-PnjyHGWhpGwRplMKPPJk6rSAp1d9TWWXVgg-bNqUzz4_sr33ICJTx7_qZzfamMqk5PDZbHOwpIj8L2DBfo3isvt6QliWmgFEOuvog' \
   -H 'Content-Range: bytes 209715200-281905831/281905832' \
   -F file=@/path/to/file_chunk_ac
+
 ```
-```text All Clients
-All api.video clients automatically use the Content-Range: bytes method to upload
-big videos for you. You don't have to set it up yourself if you use a client!
-```
+
+{% endcapture %}
+{% include "_partials/code-tabs.html" content: samples %}
+
+
+{% capture content %}
+All api.video clients automatically use the `Content-Range: bytes` method to upload big videos for you. You don't have to set it up yourself if you use a client!
+{% endcapture %}
+{% include "_partials/callout.html" kind: "info", content: content %}
 
 ## Conclusion
 


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204577546714196/1205364682863051).

Summary: Multi-tab code snippets have been migrated incorrectly from ReadMe to Doctave, and they are rendered as separate code blocks.

Fix is based on this: https://www.notion.so/apivideo/Using-Doctave-b10f8678082747c890017960a0923347?pvs=4#7a048baffc1741e4a98c6002cb16f4f1