### PR TITLE
Feature add header buttons 2

### DIFF
--- a/templates/documentation/doctave.yaml
+++ b/templates/documentation/doctave.yaml
@@ -1,5 +1,16 @@
 ---
 title: api.video documentation
+header:
+  links:
+    - external: https://community.api.video/
+      text: Community
+    - external: https://help.api.video/en/
+      text: Help Center
+    - external: https://api.video/changelog/
+      text: Changelog
+  cta:
+    external: https://dashboard.api.video/register
+    text: Sign up for free
 
 colors:
   main: "#FA5B30"


### PR DESCRIPTION
Doctave released a new version that now supports [links and CTA buttons in the header](https://docs.doctave.com/docs/contents/header-links-cta). Adding them through this commit.