### PR TITLE
Bugfix docs callouts

### DIFF
--- a/templates/documentation/delivery-analytics/analytics.md
+++ b/templates/documentation/delivery-analytics/analytics.md
@@ -35,11 +35,13 @@ After play events are collected, there is a short delay while the API processes 
 
 ## Requirements
 
-> 📘 
-> 
-> The Analytics feature is available using api.video's video player. Check out the [Video Player SDK](https://docs.api.video/docs/video-player-sdk) for details about the implementation.
-> 
-> When using third-party players, you need to implement the [Video.js](https://docs.api.video/docs/videojs-analytics-plugin) or [Hls.js](https://docs.api.video/docs/hlsjs-analytics-plugin) analytics plugins, or the analytics modules for [Android](https://github.com/apivideo/api.video-android-player-analytics) or [iOS](https://github.com/apivideo/api.video-ios-player-analytics). These enable you to collect and report play event data to api.video, so you can retrieve analytics from the API.
+{% capture content %}
+The Analytics feature is available using api.video's video player. Check out the [Video Player SDK](/sdks/player/apivideo-player-sdk.md) for details about the implementation.
+
+When using third-party players, you need to implement the [Video.js](/sdks/player/apivideo-videojs-analytics.md) or [Hls.js](/sdks/player/apivideo-hlsjs-analytics.md) analytics plugins, or the analytics modules for [Android](/sdks/player/apivideo-android-player-analytics.md) or [iOS](/sdks/player/apivideo-swift-player-analytics.md). These enable you to collect and report play event data to api.video, so you can retrieve analytics from the API.
+{% endcapture %}
+{% include "_partials/callout.html" kind: "info", content: content %}
+
 
 # Usage
 
@@ -50,9 +52,12 @@ Api.video offers 2 dedicated API endpoints for analytics:
 | [`/analytics/videos/plays`](https://docs.api.video/reference/get_analytics-videos-plays)             | Get play event count for VOD (Video on demand) |
 | [`/analytics/live-streams/plays`](https://docs.api.video/reference/get_analytics-live-streams-plays) | Get play event count for live streams          |
 
-> 📘 Testing
-> 
-> You can test the Analytics endpoints **in api.video's sandbox environment**. Check out [Environments](https://docs.api.video/reference/overview#environments) for more details. The sandbox environment returns data within the last 1-day time period.
+{% capture content %}
+**Testing**
+
+You can test the Analytics endpoints **in api.video's sandbox environment**. Check out [Environments](/reference/README.md#environments) for more details. The sandbox environment returns data within the last 1-day time period.
+{% endcapture %}
+{% include "_partials/callout.html" kind: "info", content: content %}
 
 ## Request
 
@@ -67,44 +72,17 @@ curl --request GET \
      --header 'Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDI4MDUyNzEuOTEyODMsIm5iZiI6MTY0MjgwNTI3MS45MTI4MywiZXhwIjoxNjQyODA4ODcxLjkxMjgzLCJwcm9qZWN0SWQiOiJwclJ6SUpKQTdCTHNxSGpTNDVLVnBCMSJ9.jTiB29R_sg5dqCDBU8wrnz7GRJsCzfVeLVTX-XSctS024B9OmGsuY139s2ua1HzrT63sqkBB1QshrjZbkDLVxSrs0-gt-FaM2bgvCC0lqK1HzEUL4vN2OqPPuM8R2pruj0UdGVaifGqmyfehKcHxuNr0ijGmGIMwSXkabECbXCxm7LraRCgmlobHepuXcUPeUKzKxN5LwPSO1onD684S0FtUUYbVMq9Ik7V8UznbpOjmFaknIZowKKlCkTmgKcyLSq7IaPJd7UuDJVXJDiC49oImEInrjx1xuFbyoBz_wkZlwcgk9GjksTeSz4xzBLcyzVgCwGP2hs8_BtdslXXOrA' \
 ```
 
-> 🚧 Please note
-> 
-> api.video retains play event data for 30 days. If you select a time period that is outside the 30 day retention period, the API returns a `400` error.
+{% capture content %}
+api.video retains play event data for 30 days. If you select a time period that is outside the 30 day retention period, the API returns a `400` error.
+{% endcapture %}
+{% include "_partials/callout.html" kind: "info", content: content %}
 
-[block:parameters]
-{
-  "data": {
-    "h-0": "Parameter",
-    "h-1": "Type",
-    "h-2": "Required",
-    "h-3": "Details",
-    "0-0": "`from`",
-    "0-1": "`date`",
-    "0-2": "`true`",
-    "0-3": "The start date for the time period of the analytics you would like to request.  \n  \n- The API returns analytics data **including** the day you set in `from`.  \n- A valid date value is only **within the last 30 days**.  \n- The value you provide must follow the `YYYY-MM-DD` format.",
-    "1-0": "`dimension`",
-    "1-1": "`string`",
-    "1-2": "`true`",
-    "1-3": "This parameter enables you to define a single property that you want analytics for. You can select only **one property** in your request. See the [table below for all dimension options](https://docs.api.video/docs/analytics#dimension).",
-    "2-0": "`to`",
-    "2-1": "`date`",
-    "2-2": "`false`",
-    "2-3": "Use this optional query parameter to set the end date for the time period that you want analytics for.  \n  \n- The API returns analytics data **excluding** the day you set in `to`.  \n- If you do not specify a `to` date, the API returns analytics data starting from the `from` date up until today, and **excluding** today.  \n- A valid date value is only **within the last 30 days**.  \n- The value you provide must follow the `YYYY-MM-DD` format.",
-    "3-0": "`filter`",
-    "3-1": "`key-value pair`",
-    "3-2": "`false`",
-    "3-3": "Use this parameter to filter your results to a specific video or live stream in a project that you want analytics for.  \n  \nYou must use the `videoId:` or `liveStreamId:` prefix when specifying an identifier for a video or a live stream.  \n  \nNote that the **Get play events for videos** endpoint only accepts video `ID` as a filter, and the **Get play events for live streams** endpoint only accepts live stream `ID` as a filter."
-  },
-  "cols": 4,
-  "rows": 4,
-  "align": [
-    "left",
-    "left",
-    "left",
-    "left"
-  ]
-}
-[/block]
+| Parameter  | Type  | Required  | Details  |
+|---|---|---|---|
+| `from`  | `date`  | `true`  | The start date for the time period of the analytics you would like to request.<br><br>- The API returns analytics data **including** the day you set in from.<br>- A valid date value is only **within the last 30 days**.<br>- The value you provide must follow the `YYYY-MM-DD` format.  |
+| `dimension`  | `string`  | `true`  | This parameter enables you to define a single property that you want analytics for. You can select only one property in your request. See the [table below for all dimension options](#dimension) |
+| `to`  | `date`  | `false`  | Use this optional query parameter to set the end date for the time period that you want analytics for.<br>  <br>- The API returns analytics data **excluding** the day you set in `to`.<br>- If you do not specify a `to` date, the API returns analytics data starting from the `from` date up until today, and **excluding** today.<br>- A valid date value is only **within the last 30 days**.<br>- The value you provide must follow the `YYYY-MM-DD` format.  |
+| `filter`  | `key-value pair`  | `false`  | Use this parameter to filter your results to a specific video or live stream in a project that you want analytics for.<br><br>You must use the `videoId:` or `liveStreamId:` prefix when specifying an identifier for a video or a live stream.<br><br>Note that the **Get play events for videos** endpoint only accepts video `ID` as a filter, and the **Get play events for live streams** endpoint only accepts live stream `ID` as a filter.  |
 
 ### Dimension
 
@@ -176,7 +154,6 @@ Based on your request the Analytics API returns paginated play event data in an 
 You can find sample responses for some common analytics parameters here:
 
 <details><summary><b>By <code>videoId</code></b></summary>
-<br>
 
 This response gives you a detailed breakdown for the number of play events for each video from the date you specified until today. You can use this data to understand which videos are the most popular.
 
@@ -228,7 +205,6 @@ This example uses the sandbox environment's `{base_URL}`. Check out the [**API e
 
 <details>
 <summary><b>By <code>country</code></b></summary>
-<br>
 
 This response gives you a detailed, paginated breakdown for the number of play events by country in a period of 4 days. You can use this data to understand how play events are spread out geographically, and which country has the most play events.
 

--- a/templates/documentation/delivery-analytics/private-video-delivery-web-browser.md
+++ b/templates/documentation/delivery-analytics/private-video-delivery-web-browser.md
@@ -24,10 +24,10 @@ When delivering the embedded video, we will use our in-house player to playback 
 
 
 {% capture content %}
-**❗ iframe on incognito tab/page**
+**iframes in incognito mode**
 
 When playing an embedded private video in a browser that runs in incognito mode you'll have to leverage sessions.
-Please find the guide for retaining a private session [here](/delivery-analytics/private-videos-with-custom-players-session-retention).
+Check out the guide for retaining a private session [here](/delivery-analytics/private-videos-with-custom-players-session-retention).
 {% endcapture %}
 {% include "_partials/callout.html" kind: "error", content: content %}
 
@@ -76,11 +76,3 @@ curl --request GET \
 The same method can be applied to the [Android SDK player](https://github.com/apivideo/api.video-android-player) we offer. Playing the private video is simple as just passing in the video id and private token.
 
 In the [example folder](https://github.com/apivideo/api.video-android-player/tree/main/example) you'll be able to find the implementation using just video id and the private token. 
-
-### Using api.video iOS SDK player to delivery private video
-{% capture content %}
-**🚧 Under construction**
-
-We are working on an example for iOS. Hang in there.
-{% endcapture %}
-{% include "_partials/callout.html" kind: "warning", content: content %}

--- a/templates/documentation/delivery-analytics/private-video-delivery-with-mp4-built-in-players.md
+++ b/templates/documentation/delivery-analytics/private-video-delivery-with-mp4-built-in-players.md
@@ -8,7 +8,7 @@ Private Video Delivery With Mp4 Built In Players
 ================================================
 
 {% capture content %}
-Please make sure to read [Private Videos](/delivery-analytics/video-privacy-access-management.md) in order to make sure you understand the concept of private videos before proceeding.
+api.video recommends that you read [Private Videos](/delivery-analytics/video-privacy-access-management.md) to ensure that you understand the concept of private videos before proceeding.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
@@ -95,10 +95,3 @@ mediaPlayer.setDataSource(url);
 mediaPlayer.prepare(); // might take long! (for buffering, etc)
 mediaPlayer.start();
 ```
-
-{% capture content %}
-**🚧 Under construction**
-
-We are working on an example for Android. Hang in there.
-{% endcapture %}
-{% include "_partials/callout.html" kind: "warning", content: content %}

--- a/templates/documentation/delivery-analytics/private-video-on-hls-or-external-players.md
+++ b/templates/documentation/delivery-analytics/private-video-on-hls-or-external-players.md
@@ -11,7 +11,7 @@ Private Video On Hls Or External Players
 ========================================
 
 {% capture content %}
-Please make sure to read [Private Videos](/delivery-analytics/video-privacy-access-management.md) in order to make sure you understand the concept of private videos before proceeding.
+api.video recommends that you read [Private Videos](/delivery-analytics/video-privacy-access-management.md) to ensure that you understand the concept of private videos before proceeding.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
@@ -24,15 +24,10 @@ for example, if you would like to play the video on HLS, we provide a ready made
 
 `https://vod.api.video/vod/{video id}/token/{private token}/hls/manifest.m3u8`
 
-### Serving private videos to HTML on Safari, Chrome and Firefox:
-[block:callout]
-{
-  "type": "warning",
-  "title": "HLS player on Chrome",
-  "body": "We've seen some issues with HLS player and Chrome, please be advised"
-}
-[/block]
+### Serving private videos to HTML on Safari, Chrome and Firefox
+
 You can use the video tag directly to play the video in Safari, for example:
+
 ```html
 <html>
   <head>
@@ -69,14 +64,15 @@ Example of loading the manifest with hls.js on Safari:
 </script>
 ```
 
-source: https://github.com/video-dev/hls.js/blob/master/docs/API.md#third-step-load-a-manifest
-[block:callout]
-{
-  "type": "info",
-  "title": "Test the manifest with hls.js demo",
-  "body": "You can test out and pass the manifest to this demo player that is provided by hls.js: https://hls-js.netlify.app/demo/"
-}
-[/block]
+Source: [GitHub](https://github.com/video-dev/hls.js/blob/master/docs/API.md#third-step-load-a-manifest)
+
+{% capture content %}
+**Test the manifest with hls.js demo**
+
+You can test and pass the manifest to this demo player that is provided by hls.js: https://hls-js.netlify.app/demo/
+{% endcapture %}
+{% include "_partials/callout.html" kind: "info", content: content %}
+
 ### Serving private videos dynamically
 
 In order to build a dynamically served private videos, you can leverage the [/videos](/reference/api/Videos#retrieve-a-video-object) endpoint in order to get the url of the video and private token. For example the following steps are possible:
@@ -123,7 +119,8 @@ curl --request GET \
 
 You can serve the manifest directly into the native iOS player, you can find an example below.
 
-Reference: https://developer.apple.com/documentation/avfoundation/media_playback/creating_a_basic_video_player_ios_and_tvos
+Reference: [Apple Developer docs](https://developer.apple.com/documentation/avfoundation/media_playback/creating_a_basic_video_player_ios_and_tvos)
+
 ```swift
 @IBAction func playVideo(_ sender: UIButton) {
     guard let url = URL(string: "https://vod.api.video/vod/ABC/token/XYZ/hls/manifest.m3u8") else { return }

--- a/templates/documentation/delivery-analytics/private-video-session-tokens.md
+++ b/templates/documentation/delivery-analytics/private-video-session-tokens.md
@@ -17,7 +17,7 @@ Once the session token is acquired, it is reused in all other requests to the di
 ![Imported image](/_assets/Session%20Token.jpg)
 
 {% capture content %}
-**🚧 Time to Live**
+**Time to Live**
 
 The session token TTL is 24 hours. Once the session token has expired, you will have to get a new private token and create a new session.
 {% endcapture %}

--- a/templates/documentation/delivery-analytics/private-videos-with-custom-players-session-retention.md
+++ b/templates/documentation/delivery-analytics/private-videos-with-custom-players-session-retention.md
@@ -17,8 +17,9 @@ In these cases, you will have to make multiple requests to api.video assets. As 
 ### What is a [Session Token](/delivery-analytics/private-video-session-tokens)
 
 In short a [Session Token](/delivery-analytics/private-video-session-tokens) is our way of retaining the session for every request you make to each asset. You can find the detailed article about session tokens [here](/delivery-analytics/private-video-session-tokens).
+
 {% capture content %}
-**❗️Incorrect usage of private video**
+**Example for incorrect usage of private videos**
 
 Let's take an example where you want to create a clickable thumbnail which will lead to the video. If we just write the following HTML **it will not work**, you will get a **404 error**:
 ```html
@@ -48,9 +49,9 @@ In some cases you would need to make further requests to get different assets fo
 Let look at some cases where we can build an application that will use the Session Token when delivering a private video
 
 #### Node.js example: Delivering the video with video.js and adding a thumbnail on the top
+
 {% capture content %}
-**📘 Github url to the below example**
-[https://github.com/apivideo/parivate_video_videojs_node_example](https://github.com/apivideo/parivate_video_videojs_node_example)
+You can find the source for the example below on [GitHub](https://github.com/apivideo/parivate_video_videojs_node_example).
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 

--- a/templates/documentation/delivery-analytics/video-playback-features.md
+++ b/templates/documentation/delivery-analytics/video-playback-features.md
@@ -66,7 +66,10 @@ To hide the Player's title that is displayed on the bottom left corner of the po
 
 To hide the Player's control bar, use `#hide-controls`.
 
-> Caution as you should integrate your own controls if you prevent users from accessing Api Video Player native ones.
+{% capture content %}
+Note that you need to integrate your own player controls if you hide the default api.video Player controls.
+{% endcapture %}
+{% include "_partials/callout.html" kind: "warning", content: content %}
 
 <iframe src="https://embed.api.video/vod/vi54sj9dAakOHJXKrUycCQZp#hide-controls" class="av_player" width="100%" height="300" frameborder="0" scrolling="no" allowfullscreen></iframe>
 

--- a/templates/documentation/get-started/authentication-guide.md
+++ b/templates/documentation/get-started/authentication-guide.md
@@ -9,9 +9,7 @@ With api.video, every call to the API requires authentication. We use Bearer aut
 Bearer authentication is simple to set up and use; however, we encourage you to use one of our clients if possible. api.video clients handle authentication for you, including renewing your token as needed. This guide will show you how to quickly install the client of your choice and provide the code snippet you'll need for authentication. 
 
 {% capture content %}
-**📘 NOTE:**
-
-We will show the corresponding cURL commands for each part of the tutorial when appropriate.
+This guide shows the corresponding cURL commands for each part of the tutorial where appropriate.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 

--- a/templates/documentation/get-started/create-and-manage-tokens-for-delegated-uploads.md
+++ b/templates/documentation/get-started/create-and-manage-tokens-for-delegated-uploads.md
@@ -13,9 +13,7 @@ Create And Manage Tokens For Delegated Uploads
 To complete a delegated upload, you need to create a token. You can create as many tokens as you like. If you don't include a TTL (time-to-live) for a token, then it lasts until you choose to delete it. In this guide, we will walk through how to create a token and then how to list tokens, retrieve token details, and delete a token you no longer need. 
 
 {% capture content %}
-📘 **NOTE**
-
-If you want to learn about regular or progressive uploads, please see the [Upload a video - regular, progressive, and bytes](/vod/upload-a-video-regular-upload) guide.
+If you want to learn about regular or progressive uploads, check out the [Upload a video - regular, progressive, and bytes](/vod/upload-a-video-regular-upload) guide.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 

--- a/templates/documentation/get-started/upload-a-video-with-a-delegated-token.md
+++ b/templates/documentation/get-started/upload-a-video-with-a-delegated-token.md
@@ -8,9 +8,7 @@ Upload A Video With A Delegated Token
 You can upload videos using the traditional two-step process where you create a video container then upload your video into your container. You can also upload a video using a delegated token. In this type of upload, you retrieve a token from the tokens endpoint. You can then directly upload using the token upload endpoint. It's one step, and you don't provide anything except the file. You can update the metadata for the upload later. A benefit of a delegated token is that you can make it, so it doesn't expire. You can always use the token to upload. You can also create delegated tokens for others to use to do uploads. Anyone who has a token can make an upload, so be careful how you set and manage tokens. 
 
 {% capture content %}
-📘 **NOTE**
-
-If you do a progressive upload with a delegated token, then you would have to include the video ID you are uploading to after it comes back from the first request. If the video you're uploading is under 200 MiB, you don't need to worry.
+If you do a progressive upload with a delegated token, you have to include the video ID you are uploading to after it comes back from the first request. If the video you're uploading is under 200 MiB, you don't need to worry.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 

--- a/templates/documentation/live-streaming/add-or-delete-a-live-stream-thumbnail.md
+++ b/templates/documentation/live-streaming/add-or-delete-a-live-stream-thumbnail.md
@@ -7,8 +7,6 @@ Add Or Delete A Live Stream Thumbnail
 You can add your image as the thumbnail. There is only one way to add a thumbnail to a live stream, unlike videos. This guide walks through how to add a live stream thumbnail. 
 
 {% capture content %}
-**📘 NOTE**
-
 If you want to add a thumbnail to a video, there are two methods available - you can choose an image to upload, or you can pick a frame from the video to set as the thumbnail. To learn how to do this, please see the [Add a thumbnail to your video](/vod/add-a-thumbnail-to-your-video) guide.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}

--- a/templates/documentation/live-streaming/restreams.md
+++ b/templates/documentation/live-streaming/restreams.md
@@ -40,13 +40,16 @@ The Live stream endpoint has an optional field called `restreams` which is an ar
 | `serverUrl` | `string` | The RTMP url of the streaming server.                                                             |
 | `streamKey` | `string` | Stream key provided by the streaming provider.                                                    |
 
-> 📘 
-> 
-> - Currently api.video supports up to 5 restreams
-> - At this time, it's only possible to restream to RTMP
-> - The names of the providers are arbitrary, you can provide any name you like
-> - When updating the restreams object, it's important to make sure that you are passing the previous values if you would like to keep them
-> - Modifying the restreams array while the live stream is already broadcasting will only take only effect after the stream has been restarted
+{% capture content %}
+Please note that:
+
+- Currently api.video supports up to 5 restreams
+- At this time, it's only possible to restream to RTMP
+- The names of the providers are arbitrary, you can provide any name you like
+- When updating the restreams object, it's important to make sure that you are passing the previous values if you would like to keep them
+- Modifying the restreams array while the live stream is already broadcasting will only take only effect after the stream has been restarted
+{% endcapture %}
+{% include "_partials/callout.html" kind: "warning", content: content %}
 
 ## Supported Platforms
 
@@ -66,9 +69,12 @@ In order to get started with restream, you will need to create a live stream. Ch
 
 ## Usage
 
-> 📘 Limitations
-> 
-> Restreaming in Sandbox mode is limited to 2 minutes. The original live stream is not limited, only the restreams are limited.
+{% capture content %}
+**Limitations**
+
+Restreaming in Sandbox mode is limited to 2 minutes. The original live stream is not limited, only the restreams are limited.
+{% endcapture %}
+{% include "_partials/callout.html" kind: "warning", content: content %}
 
 ### Creating a live stream with restreams
 

--- a/templates/documentation/reference/README.md
+++ b/templates/documentation/reference/README.md
@@ -22,7 +22,7 @@ Once you've upgraded you can switch between sandbox and production by toggling t
 ![](https://files.readme.io/a3713b2-Screenshot_2023-02-23_at_18.29.00.png "Screenshot 2023-02-23 at 18.29.00.png")
 
 {% capture content %}
-**🚧 The sandbox mode will have these limitations**
+**The sandbox mode has these limitations**
 
 - Limited to 30 seconds videos and live streams.
 - Will include an unremovable watermark

--- a/templates/documentation/reference/basic-authentication.md
+++ b/templates/documentation/reference/basic-authentication.md
@@ -11,7 +11,7 @@ You must use different credentials depending on the [environment](/reference/REA
 
 
 {% capture content %}
-**📘 API Key protection**
+**API Key protection**
 
 To protect your credentials from being revealed on the client-side, invoke the api.video calls from your own server-side applications only.
 
@@ -46,10 +46,10 @@ Sample requests with authentication can be found below:
   ```
 
 {% capture content %}
-**📘 Notes**
+**Notes**
 
 * Replace `api_key` with the key you have already copied from [https://dashboard.api.video](https://dashboard.api.video/)
-* **⚠️ Important: You need to keep the colon after `api_key`**
+* **Important: You need to keep the colon after `api_key`**
 * The above API request is equivalent to  
   ```bash
     curl --header 'Authorization: Basic your\_api\_key\_with\_trailing\_colon\_in\_base64' https://ws.api.video/videos

--- a/templates/documentation/reference/create-and-manage-webhooks.md
+++ b/templates/documentation/reference/create-and-manage-webhooks.md
@@ -83,7 +83,7 @@ You can test your webhooks with tools like [Pipedream](https://pipedream.com/wor
 ### Retry policy
 
 {% capture content %}
-**📘 Webhook retry policy**
+**Webhook retry policy**
 
 api.video’s webhook service makes 3 notification attempts, with 3 second intervals between each try.
 {% endcapture %}
@@ -554,7 +554,7 @@ print(response)
 {% include "_partials/code-tabs.md" samples: samples %}
 
 {% capture content %}
-⚠️  **Warning**
+**Warning**
 
 Deleting a webhook is a permanent action and deleted webhooks cannot be recovered.
 {% endcapture %}

--- a/templates/documentation/reference/video-best-practices.md
+++ b/templates/documentation/reference/video-best-practices.md
@@ -15,7 +15,7 @@ A more visual representation can be found below:
 ![](https://files.readme.io/fee60cd-Create_a_video_flowchart.png "Create a video flowchart.png")
 
 {% capture content %}
-**📘 Important things to know**
+**Important things to know**
 * **All qualities encoding:** The video object will include up to 6 responsive video streams from 240p to 4K
 * **Video size:** There's no file size limitation but the files will be compressed to fit delivery needs (4k max def with x264 + aac at 60fps max )
 * **Highest quality encoding by default:** Mp4 encoded versions are created at the highest quality (max 4K) by default.
@@ -66,7 +66,7 @@ Metadata values can be a key:value where the values are predefined, but Dynamic 
 The double underscore on both sides of the value allows any variable to be added for a given video session. Added the the url you might have:
 
 ```html
-<iframe type="text/html" src="https://embed.api.video/vod/vi6QvU9dhYCzW3BpPvPsZUa8?metadata[classUserName]=Doug" width="960" height="320" frameborder="0" scrollling="no"></iframe>
+<iframe type="text/html" src="https://embed.api.video/vod/vi6QvU9dhYCzW3BpPvPsZUa8?metadata[classUserName]=Doug" width="960" height="320" frameborder="0" scrolling="no"></iframe>
 ```
 
 This video session will be tagged as watched by Doug - allowing for in-depth analysis on how each viewer interacts with the videos.

--- a/templates/documentation/vod/add-a-permanent-watermark.md
+++ b/templates/documentation/vod/add-a-permanent-watermark.md
@@ -21,12 +21,10 @@ Overall, watermarks can be an effective way to protect intellectual property, es
 Watermarks are uploaded separately from videos. You will need to upload the watermarks you want to utilize beforehand, after the watermark is uploaded it is attached to a video object, and eventually as soon as the video is uploaded to the object, the watermark is embedded in the video
 
 {% capture content %}
-**📘 Important to know**
-
-- Watermarks are only attachable when creating a new video object
-- Watermarks cannot be deleted or edited after being added to a video
+- You can only add watermarks when creating a new video object.
+- You cannot delete or edit watermarks after you add them to a video.
 {% endcapture %}
-{% include "_partials/callout.html" kind: "info", content: content %}
+{% include "_partials/callout.html" kind: "warning", content: content %}
 
 ![](/_assets/watermark-diagram.jpg)
 
@@ -85,8 +83,6 @@ First step, would be to upload a watermark. It is recommended to use images that
 When the upload is complete, the response from the watermark endpoint will be the watermark id. You can either store it on your end or you can consume it from the list of watermarks.
 
 {% capture content %}
-**📘 Note**
-
 api.video will only store the watermark id and the time and date it was uploaded. If you would like to reference the watermark to a specific image name, you would have to do that on your end.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}

--- a/templates/documentation/vod/add-a-thumbnail-to-your-video.md
+++ b/templates/documentation/vod/add-a-thumbnail-to-your-video.md
@@ -12,8 +12,6 @@ For videos or recorded live streams, api.video offers you two ways to add a thum
 This guide walks you through both methods for setting up a thumbnail for videos. 
 
 {% capture content %}
-📘 **NOTE**
-
 If you want to add a thumbnail to a live stream, the only available method is to upload a picture you choose. You can read more about this in the [Add or delete a live stream thumbnail](/live-streaming/add-or-delete-a-live-stream-thumbnail) guide.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}

--- a/templates/documentation/vod/get-started-in-5-minutes.md
+++ b/templates/documentation/vod/get-started-in-5-minutes.md
@@ -23,9 +23,9 @@ Navigate to <https://dashboard.api.video/register> and register with your Google
 All you need now is to get your API key from the dashboard. Navigate to: <https://dashboard.api.video/apikeys> and grab your API key from there.
 
 {% capture content %}
-**🚧 API Key Security**
+**API Key Security**
 
-Please make sure to reach our security recommendation to avoid exposing your API key and causing a security breach on your account. You can find the security best practices [here](/reference/README.md#security)
+Make sure to reach our security recommendation to avoid exposing your API key and causing a security breach on your account. You can find the security best practices [here](/reference/README.md#security)
 {% endcapture %}
 {% include "_partials/callout.html" kind: "warning", content: content %}
 
@@ -66,7 +66,7 @@ $ npm run dev
 The server will be running on `localhost:3000` by default
 
 {% capture content %}
-**📘 Changing the default port**
+**Changing the default port**
 
 You can change the default port of 3000 to something of your liking by editing the `package.json` file and adding the custom port like so:
 
@@ -127,7 +127,7 @@ const ListVideoPage = (page: number) => {
 #### Server Hello World
 
 {% capture content %}
-**📘 Building the backend with the language of your choice**
+**Building the backend with the language of your choice**
 
 This tutorial is designed to get you started with our client libraries, you can choose which client library you want to work with. For each example, please make sure to choose the language of your choice in the code snippet pane.
 {% endcapture %}

--- a/templates/documentation/vod/upload-a-video-regular-upload.md
+++ b/templates/documentation/vod/upload-a-video-regular-upload.md
@@ -11,8 +11,6 @@ api.video provides different ways to upload your videos. There are two ways to u
 - Regular upload for a video that's 200MiB or more using byte range in the Content-Range header
 
 {% capture content %}
-📘 **NOTE**
-
 Megabyte (MB) and Mebibyte (MiB) are both used to measure units of information on computer storage. 1 MB is 1000Kb (kilobytes), and 1 MiB is 1048.576Kb. api.video uses MiB.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
@@ -27,8 +25,6 @@ Megabyte (MB) and Mebibyte (MiB) are both used to measure units of information o
 This section gives you an overview of your upload options. This guide walks through regular uploads but describes all the available choices here. 
 
 {% capture content %}
-📘 **NOTE**
-
 If you want to learn about delegated uploads, which are useful for creating private videos, or allowing your viewers to upload content themselves, or even just making it easier for you to do uploads, please see the [Create and manage tokens for delegated uploads](/get-started/create-and-manage-tokens-for-delegated-uploads) guide and the [Upload a video with a delegated token](/get-started/upload-a-video-with-a-delegated-token) guide.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}

--- a/templates/documentation/vod/upload-your-first-video.md
+++ b/templates/documentation/vod/upload-your-first-video.md
@@ -170,7 +170,7 @@ catch (ApiException e)
 {% include "_partials/code-tabs.md" samples: samples %}
 
 {% capture content %}
-ℹ️ Replace `your_api_key` by the key you have already copied from dashboard.api.video
+Replace `your_api_key` by the key you have already copied from dashboard.api.video
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
@@ -191,7 +191,7 @@ Remember the `videoId`: you will need it to upload your video, in [step b](#b-up
 Also, you will need the `assets.player` to playback your video in [step 3](#3-watch-your-video).
 
 {% capture content %}
-💡 If you are using one of our API clients, you will find the above information in the returned response. `Video` object.
+If you are using one of our API clients, you will find the above information in the returned response's `Video` object.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
@@ -494,7 +494,7 @@ catch (ApiException e)
 {% include "_partials/code-tabs.md" samples: samples %}
 
 {% capture content %}
-ℹ️ Replace the link in the example above with your video URL. If you don’t have a video URL handy to test this, you can use [this one](http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4) for example.
+Replace the link in the example above with your video URL. If you don’t have a video URL to test this, you can use [this one](http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4) for example.
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 


### PR DESCRIPTION
Based on [this Asana task](https://app.asana.com/0/1204577546714196/1205364682863055).

Summary: Callouts have been migrated incorrectly from ReadMe to Doctave, and they are rendered incorrectly in most cases.

Fix is based on this: https://www.notion.so/apivideo/Using-Doctave-b10f8678082747c890017960a0923347?pvs=4#0140c517afa04da786c3024640d083a2