### PR TITLE
Fix VTT formatting on Chapters page

### DIFF
--- a/templates/documentation/vod/creating-and-managing-chapters.md
+++ b/templates/documentation/vod/creating-and-managing-chapters.md
@@ -14,14 +14,13 @@ Adding chapters can make your video easier to navigate if you have a long video.
 Video chapters use the same concept as video [captions](/vod/add-captions.md) and the supported format is VTT. The chapters are listed with the timeframe in the VTT file. For example:
 
 ```
-{
-  "codes": [
-    {
-      "code": "WEBVTT  </br>  </br>  01\n00:01.000 --> 00:04.000\n\n02\n00:05.000 --> 00:09.000",
-      "language": "text"
-    }
-  ]
-}
+WEBVTT
+
+01
+00:01.000 --> 00:04.000
+
+02
+00:05.000 --> 00:09.000
 ```
 
 ### Supported chaoter file formats

--- a/templates/documentation/vod/creating-and-managing-chapters.md
+++ b/templates/documentation/vod/creating-and-managing-chapters.md
@@ -23,7 +23,7 @@ WEBVTT
 00:05.000 --> 00:09.000
 ```
 
-### Supported chaoter file formats
+### Supported chapter file formats
 
 Currently only **VTT** file format is supported.
 


### PR DESCRIPTION
Fixed incorrect VTT formatting on this page: https://api-video.doctave.dev/vod/creating-and-managing-chapters

Incorrect formatting was due to markdown artifacts from migration.

Before:

```
{
  "codes": [
    {
      "code": "WEBVTT  </br>  </br>  01\n00:01.000 --> 00:04.000\n\n02\n00:05.000 --> 00:09.000",
      "language": "text"
    }
  ]
}
```

After:

```
WEBVTT

01
00:01.000 --> 00:04.000

02
00:05.000 --> 00:09.000
```