### PR TITLE
Simplify video management basics pages

### DIFF
--- a/templates/documentation/vod/add-a-thumbnail-to-your-video.md
+++ b/templates/documentation/vod/add-a-thumbnail-to-your-video.md
@@ -16,58 +16,10 @@ If you want to add a thumbnail to a live stream, the only available method is to
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
-## Associated API reference documentation
+## API documentation
 
 - [Upload a thumbnail](/reference/api/Videos#upload-a-thumbnail)
 - [Pick a thumbnail](/reference/api/Videos#set-a-thumbnail)
-
-## Choose an api.video client
-
-The clients offered by api.video include:
-
-- [Go](https://github.com/apivideo/api.video-go-client)
-- [PHP](https://github.com/apivideo/api.video-php-client)
-- [JavaScript ](https://github.com/apivideo/api.video-nodejs-client)
-- [Python](https://github.com/apivideo/api.video-python-client)
-- [C#](https://github.com/apivideo/api.video-csharp-client)
-
-## Installation
-
-To install your selected client, do the following: 
-
-{% capture samples %}
-```go
-go get github.com/apivideo/api.video-go-client
-```
-```php
-composer require api-video/php-api-client
-```
-```javascript
-npm install @api.video/nodejs-client --save
-
-...or with yarn: 
-  
-yarn add @api.video/nodejs-client
-```
-```python
-pip install api.video
-```
-```csharp
-Using Nuget
-  
-Install-Package ApiVideo
-```
-{% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
-
-## Retrieve your API key
-
-You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
-
-1. Log in to the api.video dashboard. 
-2. From the list of choices on the left, make sure you are on **API Keys** 
-3. You will always be able to choose to use your Sandbox API key. If you want to use the Production API key instead, enter your credit card information. 
-4. Grab the key you want, and you're ready to get started! 
 
 ## Upload a thumbnail
 

--- a/templates/documentation/vod/delete-a-video.md
+++ b/templates/documentation/vod/delete-a-video.md
@@ -4,59 +4,11 @@ title: "Delete a video"
 Delete A Video
 ==============
 
-Sometimes, you need to delete a video permanently. This guide walks you through how to get rid of a video programmatically and through the dashboard. Please be aware that you cannot retrieve a video you delete, so be sure it's what you want to do.
+This guide walks you through how to permanently remove a video programmatically, and through the dashboard. Please be aware that you cannot retrieve a video you delete, so be sure it's what you want to do.
 
-## Associated API reference documentation
+## API documentation
 
 - [Delete a video](/reference/api/Videos#delete-a-video-object)
-
-## Choose an api.video client
-
-The clients offered by api.video include:
-
-- [Go](https://github.com/apivideo/api.video-go-client)
-- [PHP](https://github.com/apivideo/api.video-php-client)
-- [JavaScript ](https://github.com/apivideo/api.video-nodejs-client)
-- [Python](https://github.com/apivideo/api.video-python-client)
-- [C#](https://github.com/apivideo/api.video-csharp-client)
-
-## Installation
-
-To install your selected client, do the following: 
-   
-{% capture samples %}
-```go
-go get github.com/apivideo/api.video-go-client
-```
-```php
-composer require api-video/php-api-client
-```
-```javascript
-npm install @api.video/nodejs-client --save
-
-...or with yarn: 
-  
-yarn add @api.video/nodejs-client
-```
-```python
-pip install api.video
-```
-```csharp
-Using Nuget
-  
-Install-Package ApiVideo
-```
-{% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
-
-## Retrieve your API key
-
-You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
-
-1. Log in to the api.video dashboard. 
-2. From the list of choices on the left, make sure you are on **API Keys** 
-3. You will always be able to choose to use your Sandbox API key. If you want to use the Production API key instead, enter your credit card information. 
-4. Grab the key you want, and you're ready to get started! 
 
 ## Delete a video
 

--- a/templates/documentation/vod/list-videos-2.md
+++ b/templates/documentation/vod/list-videos-2.md
@@ -12,48 +12,9 @@ You will often need to retrieve a list of all your videos or some videos to work
 
 This guide walks through the different options for retrieving videos and covers a method for searching for them using your dashboard. 
 
-## Associated API reference documentation
+## API documentation
 
-- [List all videos](/reference/api/Videos#list-all-video-objects) 
-
-## Choose an api.video client
-
-The clients offered by api.video include:
-
-- [Go](https://github.com/apivideo/api.video-go-client)
-- [PHP](https://github.com/apivideo/api.video-php-client)
-- [JavaScript ](https://github.com/apivideo/api.video-nodejs-client)
-- [Python](https://github.com/apivideo/api.video-python-client)
-- [C#](https://github.com/apivideo/api.video-csharp-client)
-
-## Installation
-
-To install your selected client, do the following: 
-
-{% capture samples %}
-```go
-go get github.com/apivideo/api.video-go-client
-```
-```php
-composer require api-video/php-api-client
-```
-```javascript
-npm install @api.video/nodejs-client --save
-
-...or with yarn: 
-  
-yarn add @api.video/nodejs-client
-```
-```python
-pip install api.video
-```
-```csharp
-Using Nuget
-  
-Install-Package ApiVideo
-```
-{% endcapture %}
-{% include "_partials/code-tabs.html" content: samples %}
+- [List all videos](/reference/api/Videos#list-all-video-objects)
 
 ## List all videos
 

--- a/templates/documentation/vod/navigation.yaml
+++ b/templates/documentation/vod/navigation.yaml
@@ -37,7 +37,8 @@
 
 - heading: Video management
   items:
-  - subheading: Video management basics
+  - label: Video management basics
+    href: /vod/video-management-basics.md
     collapsed: true
     items:
     - label: List Videos

--- a/templates/documentation/vod/show-video-details.md
+++ b/templates/documentation/vod/show-video-details.md
@@ -7,57 +7,9 @@ Show Video Details
 
 You can retrieve details for a specific video if you have the video ID. In this guide, we'll walk through the code to retrieve it and how to retrieve it from the dashboard.
 
-## Associated API reference documentation
+## API documentation
 
 - [Show a video](/reference/api/Videos#retrieve-a-video-object)
-
-## Choose an api.video client
-
-The clients offered by api.video include:
-
-- [Go](https://github.com/apivideo/api.video-go-client)
-- [PHP](https://github.com/apivideo/api.video-php-client)
-- [JavaScript ](https://github.com/apivideo/api.video-nodejs-client)
-- [Python](https://github.com/apivideo/api.video-python-client)
-- [C#](https://github.com/apivideo/api.video-csharp-client)
-
-## Installation
-
-To install your selected client, do the following: 
-
-{% capture samples %}
-```go
-go get github.com/apivideo/api.video-go-client
-```
-```php
-composer require api-video/php-api-client
-```
-```javascript
-npm install @api.video/nodejs-client --save
-
-...or with yarn: 
-  
-yarn add @api.video/nodejs-client
-```
-```python
-pip install api.video
-```
-```csharp
-Using Nuget
-  
-Install-Package ApiVideo
-```
-{% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
-
-## Retrieve your API key
-
-You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
-
-1. Log in to the api.video dashboard. 
-2. From the list of choices on the left, make sure you are on **API Keys** 
-3. You will always be able to choose to use your Sandbox API key. If you want to use the Production API key instead, enter your credit card information. 
-4. Grab the key you want, and you're ready to get started! 
 
 ## Retrieve video info
 

--- a/templates/documentation/vod/update-video-details.md
+++ b/templates/documentation/vod/update-video-details.md
@@ -6,57 +6,9 @@ Update Video Details
 
 You can update details for a video after you've uploaded it. The only things you can't change are the video ID, the content of the video, and the watermark. This guide walks through two ways you can make an update - programmatically and through the dashboard.
 
-## Associated API reference documentation
+## API documentation
 
-- [Update a video](/reference/api/Videos#update-a-video-object) 
-
-## Choose an api.video client
-
-The clients offered by api.video include:
-
-- [Go](https://github.com/apivideo/api.video-go-client)
-- [PHP](https://github.com/apivideo/api.video-php-client)
-- [JavaScript ](https://github.com/apivideo/api.video-nodejs-client)
-- [Python](https://github.com/apivideo/api.video-python-client)
-- [C#](https://github.com/apivideo/api.video-csharp-client)
-
-## Installation
-
-To install your selected client, do the following: 
-
-{% capture samples %}
-```go
-go get github.com/apivideo/api.video-go-client
-```
-```php
-composer require api-video/php-api-client
-```
-```javascript
-npm install @api.video/nodejs-client --save
-
-...or with yarn: 
-  
-yarn add @api.video/nodejs-client
-```
-```python
-pip install api.video
-```
-```csharp
-Using Nuget
-  
-Install-Package ApiVideo
-```
-{% endcapture %}
-{% include "_partials/code-tabs.md" samples: samples %}
-
-## Retrieve your API key
-
-You'll need your API key to get started. You can sign up for one here: [Get your api.video API key!](https://dashboard.api.video/register). Then do the following: 
-
-1. Log in to the api.video dashboard. 
-2. From the list of choices on the left, make sure you are on **API Keys** 
-3. You will always be able to choose to use your Sandbox API key. If you want to use the Production API key instead, enter your credit card information. 
-4. Grab the key you want, and you're ready to get started! 
+- [Update a video](/reference/api/Videos#update-a-video-object)
 
 ## Update video details
 

--- a/templates/documentation/vod/video-management-basics.md
+++ b/templates/documentation/vod/video-management-basics.md
@@ -1,1 +1,76 @@
-what-is-api-video.md
+---
+title: "Video management basics"
+slug: "video-management-basics"
+meta:
+  description: This page serves as a foundational guide to the different operations using api.video's solutions for video on demand (VOD). These are list videos, show and update video details, add thumbnail to videos, and delete videos.
+---
+
+## Video management basics
+
+This page serves as a foundational guide to the different operations you can use in api.video's solutions for video on demand (VOD). 
+
+Before jumping into the different operations, follow these steps to set up your work environment:
+
+### Choose an API client
+
+The clients offered by api.video include:
+
+- [NodeJS](/sdks/api-clients/apivideo-nodejs-client.md)
+- [Python](/sdks/api-clients/apivideo-python-client.md)
+- [PHP](/sdks/api-clients/apivideo-php-client.md)
+- [Go](/sdks/api-clients/apivideo-go-client.md)
+- [C#](/sdks/api-clients/apivideo-csharp-client.md)
+- [Java](/sdks/api-clients/apivideo-java-client.md)
+- [iOS](/sdks/api-clients/ios-api-client.md)
+- [Android](/sdks/api-clients/android-api-client.md)
+
+
+### Install
+
+To install your selected client, do the following: 
+
+{% capture samples %}
+```go
+go get github.com/apivideo/api.video-go-client
+```
+```php
+composer require api-video/php-api-client
+```
+```javascript
+npm install @api.video/nodejs-client --save
+
+...or with yarn: 
+  
+yarn add @api.video/nodejs-client
+```
+```python
+pip install api.video
+```
+```csharp
+Using Nuget
+  
+Install-Package ApiVideo
+```
+{% endcapture %}
+{% include "_partials/code-tabs.md" samples: samples %}
+
+Check out the [API clients library](/sdks/api-clients.md) for detailed instructions for all libraries & SDKs.
+
+### Retrieve your API key
+
+You'll need your API key to get started. You can sign up to the [api.video dashboard](https://dashboard.api.video/register) for free. Then do the following: 
+
+1. Log in to the api.video dashboard. 
+2. From the list of choices on the left, make sure you are on **API Keys** 
+3. Choose your Sandbox API key. If you want to use the Production API key instead, you will need to enter your credit card information. 
+4. Grab the key you want, and you're ready to get started!
+
+## Next steps
+
+Check out the different operations for basic video management:
+
+- [List videos](/vod/list-videos-2.md)
+- [Show video details](/vod/show-video-details.md)
+- [Update video details](/vod/update-video-details.md)
+- [Add a thumbnail to your video](/vod/add-a-thumbnail-to-your-video.md)
+- [Delete a video](/vod/delete-a-video.md)


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204370684353095/1205405872477623).

Summary: 

- I moved these sections to parent page `templates\documentation\vod\video-management-basics.md`:
   - Choose an api.video client
   - Installation
   - Retrieve your API key

- I removed above sections from all child pages under Video management basics:
   - List Videos
   - Show Video Details
   - Update Video Details
   - Add A Thumbnail To Your Video
   - Delete A Video