### PR TITLE
Fix error page structure

### DIFF
--- a/templates/documentation/reference/navigation.yaml
+++ b/templates/documentation/reference/navigation.yaml
@@ -64,38 +64,20 @@
       items:
         - label: Invalid API key
           href: ./authentication-invalid-api-key-1.md
-          collapsed: true
-          items:
-            - label: Invalid Access Token
-              href: ./authentication-invalid-access-token-1.md
-              collapsed: true
-              items: 
-                - label: Invalid Upload Token
-                  href: ./authentication-invalid-upload-token-1.md
-            - label: Invalid Refresh Token
-              href: ./authentication-invalid-refresh-token-1.md
-            - label: Invalid Authorization Header Value
-              href: ./authentication-invalid-authorization-header-value-1.md
-            - label: Missing Authorization Header
-              href: ./authentication-missing-authorization-header-1.md
-            - label: Missing upload token
-              href: ./authentication-missing-upload-token-1.md
-            - label: Suspended account
-              href: ./authorization-suspended-account-1.md
-            - label: Invalid Access Token
-              href: ./authentication-invalid-access-token-1.md
-            - label: Invalid Upload Token
-              href: ./authentication-invalid-upload-token-1.md
-            - label: Invalid Refresh Token
-              href: ./authentication-invalid-refresh-token-1.md
-            - label: Invalid Authorization Header Value
-              href: ./authentication-invalid-authorization-header-value-1.md
-            - label: Missing Authorization Header
-              href: ./authentication-missing-authorization-header-1.md
-            - label: Missing upload token
-              href: ./authentication-missing-upload-token-1.md
-            - label: Suspended account
-              href: ./authorization-suspended-account-1.md
+        - label: Invalid Access Token
+          href: ./authentication-invalid-access-token-1.md
+        - label: Invalid Upload Token
+          href: ./authentication-invalid-upload-token-1.md
+        - label: Invalid Refresh Token
+          href: ./authentication-invalid-refresh-token-1.md
+        - label: Invalid Authorization Header Value
+          href: ./authentication-invalid-authorization-header-value-1.md
+        - label: Missing Authorization Header
+          href: ./authentication-missing-authorization-header-1.md
+        - label: Missing upload token
+          href: ./authentication-missing-upload-token-1.md
+        - label: Suspended account
+          href: ./authorization-suspended-account-1.md
     - label: General Errors
       href: ./general-errors.md
       collapsed: true


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204307844224163/1205437532729412).

The [Authentication Errors](https://docs.api.video/reference/errors) section in the API reference had some issues due to migration, I fixed it according to the original page structure.

