### PR TITLE
Update migration guides and nocode sdk landing

### DIFF
--- a/templates/documentation/get-started/migration-guides.md
+++ b/templates/documentation/get-started/migration-guides.md
@@ -8,9 +8,7 @@ meta:
 Migration guides
 =============
 
-This page gets users started on how to migrate to api.video from other platforms.
+Moving to a different provider takes time, effort, and development resources. api.video can help you migrate your existing content cost-efficiently, in only a few clicks. Read more about using our [Import tool](https://api.video/blog/tutorials/switch-to-api-video-in-minutes-latest-updates-on-our-import-tool/), or check out the migration guides if you plan to move from these providers:
 
-We should link to these platform-specific guides:
-
-- [Azure](./azure-migration.md)
-- [AWS](./aws-migration.md)
+- [Azure Media Services](./azure-migration.md)
+- [Amazon S3](./aws-migration.md)

--- a/templates/documentation/get-started/migration-guides.md
+++ b/templates/documentation/get-started/migration-guides.md
@@ -1,6 +1,7 @@
 ---
 title: "Migration guides"
 slug: "migration-guides"
+hide_side_table_of_contents: true
 meta:
   description: This page gets users started on how to migrate to api.video from other platforms.
 ---

--- a/templates/documentation/sdks/nocode/README.md
+++ b/templates/documentation/sdks/nocode/README.md
@@ -9,7 +9,7 @@ meta:
 No-code solutions
 ==================
 
-Seamlessly integrate video on demand or live streaming into your application with no code!
+Sometimes you need a quick solution without getting into coding. api.video provides you with a variety of plugins and solutions that will enable you to use api.video's various features without the need to write a single line of code.
 
 <div class="hagrid">
 


### PR DESCRIPTION
**Summary**:

- add intro text to [Migration guides landing page](https://api-video.doctave.dev/get-started/migration-guides)
- fix link texts
- hide table of contents
- also piggybacking on this commit, updating the text on the [no-code SDK landing page](https://api-video.doctave.dev/sdks/nocode)