### PR TITLE
Update page nav structure

### DIFF
--- a/templates/documentation/delivery-analytics/navigation.yaml
+++ b/templates/documentation/delivery-analytics/navigation.yaml
@@ -3,8 +3,6 @@
   items:
   - label: How does video delivery work? 
     href: /delivery-analytics/README.md
-  - label: Delivery best practices
-    href: /delivery-analytics/player-best-practices.md
   - label: Delivery & Analytics quickstart
     href: /delivery-analytics/delivery-analytics-quickstart.md
 - heading: Features
@@ -31,8 +29,6 @@
       href: /delivery-analytics/private-videos-with-custom-players-session-retention.md
     - label: Private video session tokens
       href: /delivery-analytics/private-video-session-tokens.md
-    - label: Video security best practices
-      href: /delivery-analytics/video-security-best-practices.md
 
 - heading: Players
   items:
@@ -47,11 +43,7 @@
 
 - heading: Analytics
   items:
+  - label: Analytics & data
+    href: /delivery-analytics/analytics.md
   - label: Analytics SDKs
     href: /sdks/player/README.md#player-analytics-sdks
-  - label: Player analytics
-    href: /delivery-analytics/analytics.md
-    collapsed: true
-    items:
-    - label: How to - analytics with api.video Player SDK
-      href: /delivery-analytics/how-to-player-sdk-analytics.md

--- a/templates/documentation/reference/navigation.yaml
+++ b/templates/documentation/reference/navigation.yaml
@@ -3,18 +3,18 @@
   items:
     - label: Introduction
       href: ././README.md
-    - label: Authentication
-      href: ./authentication-guide.md
-    - label: Postman Collection
+    - label: Postman collection
       href: ./postman-collection.md
     - label: Webhooks
       href: ./create-and-manage-webhooks.md
 
 - heading: Authentication
   items:
+    - label: Overview
+      href: ./authentication-guide.md
     - label: Basic authentication
       href: ./basic-authentication.md
-    - label: Disposable Bearer Token Authentication (Optional)
+    - label: Bearer token authentication
       href: ./disposable-bearer-token-authentication.md
     - open_api_spec: openapi.yaml
       only:

--- a/templates/documentation/vod/demo-loom-clone.md
+++ b/templates/documentation/vod/demo-loom-clone.md
@@ -1,5 +1,5 @@
 ---
-title: "Loom clone"
+title: "Loom mockup"
 ---
 
 # Loom clone

--- a/templates/documentation/vod/navigation.yaml
+++ b/templates/documentation/vod/navigation.yaml
@@ -63,12 +63,8 @@
       href: /vod/add-a-thumbnail-to-your-video.md
     - label: Delete A Video
       href: /vod/delete-a-video.md
-    - label: Downloading videos
-      href: /vod/downloading-videos.md
   - label: Video status & details
     href: /vod/show-video-upload-status.md
-  - label: Video tagging
-    href: /vod/video-tagging.md
 
 
 - heading: Annotations & branding


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204370684353095/1205479956570331).

**Summary**:

- Move and rename [Analytics page](https://api-video.doctave.dev/delivery-analytics/analytics)
- Move and rename [Authentication page](https://api-video.doctave.dev/reference/authentication-guide)
- Rename [Bearer Token Authentication page](https://api-video.doctave.dev/reference/disposable-bearer-token-authentication)
- Fix Loom clone page title to [Loom mockup](https://api-video.doctave.dev/vod/demo-loom-clone)
- Hide currently empty pages from all navigation.yaml files:

```
- label: How to - analytics with api.video Player SDK
      href: /delivery-analytics/how-to-player-sdk-analytics.md
- label: Video security best practices
      href: /delivery-analytics/video-security-best-practices.md
- label: Delivery best practices
    href: /delivery-analytics/player-best-practices.md
- label: Downloading videos
      href: /vod/downloading-videos.md
- label: Video tagging
    href: /vod/video-tagging.md
```