### PR TITLE
Add cards for Delivery & analytics quickstart

### DIFF
--- a/templates/documentation/README.md
+++ b/templates/documentation/README.md
@@ -62,7 +62,8 @@ api.video lets you customize a large part of the delivery, whether it's the play
 {% capture get-started-links %}
 {% include "_partials/quick-link.md" icon: "/_assets/icons/setup-checklist.svg", label: "Start building with api.video", link: "/get-started/start-building" %}
 {% include "_partials/quick-link.md" icon: "/_assets/icons/vod-quickstart.svg", label: "VOD quickstart", link: "/vod/get-started-in-5-minutes" %}
-{% include "_partials/quick-link.md" icon: "/_assets/icons/livestream-quickstart.svg", label: "Live streaming quickstart", link: "/live-streaming/create-a-live-stream" %}
+{% include "_partials/quick-link.md" icon: "/_assets/icons/livestream-quickstart.svg", label: "Live streaming quickstart", link: "/live-streaming/create-a-live-stream" %}icon: "/_assets/icons/vod-quickstart.svg", label: "VOD quickstart", link: "/vod/get-started-in-5-minutes" %}
+{% include "_partials/quick-link.md" icon: "/_assets/icons/player-customization.svg", label: "Delivery & analytics quickstart", link: "/delivery-analytics/delivery-analytics-quickstart" %}
 {% endcapture %}
 
 {% capture libraries-sdks %}

--- a/templates/documentation/delivery-analytics/README.md
+++ b/templates/documentation/delivery-analytics/README.md
@@ -35,7 +35,7 @@ meta:
 </div>
 
 <div class="content-cards">
-{% include "_partials/content-card.md" label: "Best practices for delivery", icon: "/_assets/icons/js.svg", description: "Learn how to make the most of your delivery.", link: "/delivery-analytics/player-best-practices" %}
+{% include "_partials/content-card.md" label: "Delivery & analytics quickstart", icon: "/_assets/icons/player-customization.svg", description: "Learn how to make the most of your content delivery through branding, customization, and gathering analytics.", link: "/delivery-analytics/delivery-analytics-quickstart" %}
 {% include "_partials/content-card.md" label: "Analytics", icon: "/_assets/icons/analytics.svg", description: "Start collecting delivery event data about your videos and live streams.", link: "/delivery-analytics/analytics" %}
 {% include "_partials/content-card.md" label: "Using custom domains", icon: "/_assets/icons/custom-domains.svg", description: "Maintain your company branding by delivering through custom domains", link: "/delivery-analytics/using-custom-domains" %}
 {% include "_partials/content-card.md" label: "Domain referrer restrictions", icon: "/_assets/icons/js.svg", description: "Make sure that your videos and live streams are delivered securely, and only through your domains", link: "/delivery-analytics/domain-referrer" %}

--- a/templates/documentation/doctave.yaml
+++ b/templates/documentation/doctave.yaml
@@ -8,6 +8,8 @@ header:
       text: Help Center
     - external: https://api.video/changelog/
       text: Changelog
+    - external: https://status.api.video/
+      text: API status
   cta:
     external: https://dashboard.api.video/register
     text: Sign up for free


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204370684353095/1205483627562533).

**Summary**:

- Add content card for Delivery & analytics quickstart page on the [main landing page](https://api-video.doctave.dev/#quick-links), and the [Delivery & analytics landing page](https://api-video.doctave.dev/delivery-analytics#start-delivering-with-apivideo)
- Add "API status" link to header