### PR TITLE
Update improt tool nav link

### DIFF
--- a/templates/documentation/navigation.yaml
+++ b/templates/documentation/navigation.yaml
@@ -13,6 +13,6 @@
     - label: Amazon S3
       href: /get-started/aws-migration.md
     - label: api.video import tool
-      external: https://api.video/blog/tutorials/switch-to-api-video-in-minutes-latest-updates-on-our-import-tool/
+      external: https://import.api.video/
   - label: SDK Catalog
     href: /sdks/README.md


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204577546714196/1205503121033208).

Summary: The Import tool link on [this page](https://api-video.doctave.dev/get-started/) should actually point to the import tool, and not a blog post about the import tool.