### PR TITLE
Rename API status header link

### DIFF
--- a/templates/documentation/doctave.yaml
+++ b/templates/documentation/doctave.yaml
@@ -9,7 +9,7 @@ header:
     - external: https://api.video/changelog/
       text: Changelog
     - external: https://status.api.video/
-      text: API status
+      text: Status page
   cta:
     external: https://dashboard.api.video/register
     text: Sign up for free


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204577546714196/1205503121033220).

Summary: renamed "API Status" to "Status page".