### PR TITLE
Add player logo file contraints to API reference

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -8894,7 +8894,11 @@ paths:
       tags:
         - Player Themes
       summary: Upload a logo
-      description: Upload an image logo for a player.
+      description: |
+          Upload an image file as a logo for your player. The image should fit within these constraints:
+          - The image mime type must be `image/jpeg` or `image/png`. api.video recommends using `png` images with transparent background.
+          - The image size should be a maximum of 200px width x 100px.
+          - The file size should be a maximum of 100 KiB.
       operationId: POST_players-playerId-logo
       parameters:
         - name: playerId


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205448597201625/1205463553222545).

**Summary**:

I added the player logo file constraints to the description of the `/players/{playerId}/logo` request.