### PR TITLE
Fix quick link cards CSS

### DIFF
--- a/templates/documentation/_assets/css/components/quick-link.css
+++ b/templates/documentation/_assets/css/components/quick-link.css
@@ -52,7 +52,7 @@
   );
 }
 
-.quick-links-item.understand .color-rectancle {
+.quick-links-item.resources .color-rectancle {
   background: linear-gradient(90deg, #414f6e 0%, #2773aa 100%);
 }
 


### PR DESCRIPTION
This PR is to fix an error introduced in [PR #275](https://github.com/apivideo/api.video-api-client-generator/pull/275).

**Summary**: 

`.quick-links-item.understand` CSS class was renamed to `.quick-links-item.resources` to fix the problem ✅ 