### PR TITLE
Fix live stream thumbnail URL

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4064,7 +4064,7 @@ paths:
                           iframe: '<iframe src="https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>'
                           player: 'https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr'
                           hls: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8'
-                          thumbnail: 'https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
+                          thumbnail: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
                       - liveStreamId: li4pqNqGUkhKfWcBGpZVLRY5
                         createdAt: '2020-07-29T10:45:35.000Z'
                         updatedAt: '2020-07-29T10:45:35.000Z'
@@ -12614,7 +12614,7 @@ components:
           type: string
           description: A link to the thumbnail for your video.
           format: uri
-          example: 'https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
+          example: 'https://live.api.video/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg'
     live-stream-session-session:
       title: LiveStreamSessionSession
       type: object

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4083,7 +4083,7 @@ paths:
                           iframe: '<iframe src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>'
                           player: 'https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5'
                           hls: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8'
-                          thumbnail: 'https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg'
+                          thumbnail: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg'
                     pagination:
                       currentPage: 1
                       currentPageItems: 19
@@ -11044,7 +11044,7 @@ components:
           iframe: '<iframe src="https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5" width="100%" height="100%" frameborder="0" scrolling="no" allowfullscreen=""></iframe>'
           player: 'https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5'
           hls: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8'
-          thumbnail: 'https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg'
+          thumbnail: 'https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg'
   schemas:
     link:
       type: object

--- a/templates/java/statics/android/src/test/java/video/api/client/api/clients/LiveStreamsApiTest.java
+++ b/templates/java/statics/android/src/test/java/video/api/client/api/clients/LiveStreamsApiTest.java
@@ -131,7 +131,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                             "<iframe src=\"https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                             .player(URI.create("https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr"))
                             .hls(URI.create("https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8"))
-                            .thumbnail(URI.create("https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg")))
+                            .thumbnail(URI.create("https://live.api.video/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg")))
                     .restreams(Arrays.asList(
                             new RestreamsResponseObject().name("YouTube")
                                     .serverUrl("rtmp://youtube.broadcast.example.com")
@@ -148,7 +148,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
                                     .thumbnail(URI.create(
-                                            "https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")))
+                                            "https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")))
                             .restreams(Arrays.asList(
                                     new RestreamsResponseObject().name("YouTube")
                                             .serverUrl("rtmp://youtube.broadcast.example.com")
@@ -191,7 +191,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
     }
 
@@ -230,7 +230,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
 
         @Test
@@ -281,7 +281,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
 
         @Test

--- a/templates/java/statics/java/src/test/java/video/api/client/api/clients/LiveStreamsApiTest.java
+++ b/templates/java/statics/java/src/test/java/video/api/client/api/clients/LiveStreamsApiTest.java
@@ -121,7 +121,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                                     "<iframe src=\"https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                                     .player(URI.create("https://embed.api.video/live/li400mYKSgQ6xs7taUeSaEKr"))
                                     .hls(URI.create("https://live.api.video/li400mYKSgQ6xs7taUeSaEKr.m3u8")).thumbnail(
-                                            URI.create("https://cdn.api.video/live/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg")))
+                                            URI.create("https://live.api.video/li400mYKSgQ6xs7taUeSaEKr/thumbnail.jpg")))
                             .restreams(Arrays.asList(
                                     new RestreamsResponseObject().name("YouTube").serverUrl("rtmp://youtube.broadcast.example.com").streamKey("cc1b4df0-d1c5-4064-a8f9-9f0368385188"),
                                     new RestreamsResponseObject().name("Twitch").serverUrl("rtmp://twitch.broadcast.example.com").streamKey("cc1b4df0-d1c5-4064-a8f9-9f0368385188"))),
@@ -134,7 +134,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
                                     .thumbnail(URI.create(
-                                            "https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")))
+                                            "https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")))
                             .restreams(Arrays.asList(
                                     new RestreamsResponseObject().name("YouTube").serverUrl("rtmp://youtube.broadcast.example.com").streamKey("cc1b4df0-d1c5-4064-a8f9-9f0368385135"),
                                     new RestreamsResponseObject().name("Twitch").serverUrl("rtmp://twitch.broadcast.example.com").streamKey("cc1b4df0-d1c5-4064-a8f9-9f0368385135"))));
@@ -172,7 +172,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
     }
 
@@ -211,7 +211,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
 
         @Test
@@ -259,7 +259,7 @@ public class LiveStreamsApiTest extends AbstractApiTest {
                     "<iframe src=\"https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5\" width=\"100%\" height=\"100%\" frameborder=\"0\" scrolling=\"no\" allowfullscreen=\"\"></iframe>")
                     .player(URI.create("https://embed.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5"))
                     .hls(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5.m3u8"))
-                    .thumbnail(URI.create("https://cdn.api.video/live/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
+                    .thumbnail(URI.create("https://live.api.video/li4pqNqGUkhKfWcBGpZVLRY5/thumbnail.jpg")));
         }
 
         @Test


### PR DESCRIPTION
As reported by @ThibaultBee: 

> in the API Reference of the Live Streams the thumbnail does not have a correct URL.

**Summary**:

I modified `cdn.api.video/live` to `live.api.video` in 2 instances.