### PR TITLE
Add missing Analytics redirects

### DIFF
--- a/templates/documentation/doctave.yaml
+++ b/templates/documentation/doctave.yaml
@@ -355,3 +355,9 @@ redirects:
     to: /reference/invalid-query-parameter
   - from: /reference/useful-tools
     to: /
+  - from: /reference/get_analytics-videos-videoid
+    to: /delivery-analytics/analytics
+  - from: /reference/get_analytics-sessions-sessionid-events
+    to: /delivery-analytics/analytics
+  - from: /reference/get_analytics-live-streams-livestreamid
+    to: /delivery-analytics/analytics


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205448597201625/1205555708728069).

**Summary**: I added 3 redirects from the old Analytics endpoints to the new Analytics page.