### PR TITLE
Add alt texts to images in partials

### DIFF
--- a/templates/documentation/_partials/dark-light-image.md
+++ b/templates/documentation/_partials/dark-light-image.md
@@ -1,6 +1,6 @@
 <div class="dark-light-image">
 
-<span class="dark">![]({{dark}})</span>
-<span class="light">![]({{light}})</span>
+<span class="dark">![{{alt}}]({{dark}})</span>
+<span class="light">![{{alt}}]({{light}})</span>
 
 </div>  

--- a/templates/documentation/delivery-analytics/private-video-get-started.md
+++ b/templates/documentation/delivery-analytics/private-video-get-started.md
@@ -38,7 +38,7 @@ After you learn how private video works and what it’s good for, we can now tal
 
 To reiterate the private video concept, here’s a visual representation of how the whole thing works:
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-videos-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-videos-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-videos-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-videos-light.svg", alt: "A diagram that shows the process of using private tokens" %}
 
 Knowing that now we can finally start building stuff! 
 
@@ -145,7 +145,7 @@ There are two types of tokens for private videos:
 
 At a very high level, to request different assets for the same private video, more than having the private token is required; you also need to retain the session. For that, we have the session token. In the flowchart below, you can see that for each private video, we are using a session token + the private token:
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/single-session-token-dark.svg", light: "/_assets/delivery-analytics/private-videos/single-session-token-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/single-session-token-dark.svg", light: "/_assets/delivery-analytics/private-videos/single-session-token-light.svg", alt: "A diagram that shows the steps of using a session token" %}
 
 So let’s get a bit technical here. To start the session, you will need to request the `/session` endpoint, get the session token, add it to the first asset you request, and then add it to every following asset you request. In the example above, we will request the `/session` endpoint, then add the session token to the query string of the private video thumbnail → request an embedded video asset with the session token in the query string → request a private video asset in mp4 format with the session token, and so on, you get the idea.
 

--- a/templates/documentation/delivery-analytics/private-video-session-tokens.md
+++ b/templates/documentation/delivery-analytics/private-video-session-tokens.md
@@ -15,7 +15,7 @@ The session starts with the /session endpoint where we get the session token fro
 
 Once the session token is acquired, it is reused in all other requests to the different assets.
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/session-token-dark.svg", light: "/_assets/delivery-analytics/private-videos/session-token-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/session-token-dark.svg", light: "/_assets/delivery-analytics/private-videos/session-token-light.svg", alt: "A diagram that shows the session token flow" %}
 
 {% capture content %}
 **Time to Live**

--- a/templates/documentation/delivery-analytics/using-custom-domains.md
+++ b/templates/documentation/delivery-analytics/using-custom-domains.md
@@ -10,7 +10,7 @@ Using Custom Domains
 
 api.video enables you to deliver video content and provide live streams using your own custom domains. You can decide what custom URL or subdomain you use in your implementation, for example `live.mycustomdomain.com`.
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/custom-domains/custom-domains-dark.svg", light: "/_assets/delivery-analytics/custom-domains/custom-domains-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/custom-domains/custom-domains-dark.svg", light: "/_assets/delivery-analytics/custom-domains/custom-domains-light.svg", alt: "A diagram that shows the steps of requesting and using custom domains" %}
 
 You can maintain your company branding by utilizing custom domains in any of these use cases, and more:
 

--- a/templates/documentation/delivery-analytics/video-privacy-access-management.md
+++ b/templates/documentation/delivery-analytics/video-privacy-access-management.md
@@ -16,7 +16,7 @@ A **private token** is a string of unique numbers and letters. For example: `009
 {% endcapture %}
 {% include "_partials/callout.html" kind: "info", content: content %}
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-videos-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-videos-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-videos-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-videos-light.svg", alt: "A diagram that shows the process of using private tokens" %}
 
 ### How to create private videos?
 
@@ -40,6 +40,6 @@ You can see that for each url the token will be included in different places. Fo
 
 You can [retrieve a video](/reference/api/Videos#retrieve-a-video-object) via the API, which will generate the private token while you retrieve it. Each time you make a new request to retrieve a video it will generate a new private token. Hence, if the same user would like to play the video multiple times, on different pages you'll need to make a request to the `https://ws.api.video/videos/{videoId}` endpoint mentioned above in order to get a new private token.
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-video-reusability-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-video-reusability-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/delivery-analytics/private-videos/private-video-reusability-dark.svg", light: "/_assets/delivery-analytics/private-videos/private-video-reusability-light.svg", alt: "A diagram that shows the process of reusing private videos" %}
 
 Once you've retrieved the video you can either use api.video player or an external player to play it back for the user. Hence the user can play it back for as long as the session lives, which is 24 hours in this case. When the session has ended, you will have to generate a new private token.

--- a/templates/documentation/get-started/start-building.md
+++ b/templates/documentation/get-started/start-building.md
@@ -13,7 +13,7 @@ This documentation serves as your foundational guide to integrating api.video's 
 
 ## What is api.video?
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/get-started/start-building/what-is-api-video-dark.svg", light: "/_assets/get-started/start-building/what-is-api-video-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/get-started/start-building/what-is-api-video-dark.svg", light: "/_assets/get-started/start-building/what-is-api-video-light.svg", alt: "A diagram that shows how api.video works" %}
 
 api.video is a cloud-based video hosting and live streaming platform that provides developers and businesses with an easy-to-use API to handle all video-related tasks. The platform offers a range of features to help developers and businesses manage video content, including video hosting, transcoding, player customization, live streaming, and analytics.
 

--- a/templates/documentation/live-streaming/restreams.md
+++ b/templates/documentation/live-streaming/restreams.md
@@ -18,7 +18,7 @@ api.video gives you the ability to broadcast a live stream to multiple platforms
 
 ## How it works
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/live-streaming/restreams/restreams-dark.svg", light: "/_assets/live-streaming/restreams/restreams-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/live-streaming/restreams/restreams-dark.svg", light: "/_assets/live-streaming/restreams/restreams-light.svg", alt: "A diagram that shows RTMP restreaming on different platforms" %}
 
 You can add restreams to an existing live stream or you can create a live stream that already includes the restream list.   
 

--- a/templates/documentation/reference/authentication-guide.md
+++ b/templates/documentation/reference/authentication-guide.md
@@ -56,7 +56,7 @@ Bearer authentication (also called token authentication) is an HTTP authenticati
 
 api.video provides an enhanced security authentication method, which uses a disposable bearer token that has a short time to live and has to be refreshed every 3600 seconds.
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/reference/authentication/disposable-bearer-token-dark.svg", light: "/_assets/reference/authentication/disposable-bearer-token-light.svg" %} 
+{% include "_partials/dark-light-image.md" dark: "/_assets/reference/authentication/disposable-bearer-token-dark.svg", light: "/_assets/reference/authentication/disposable-bearer-token-light.svg", alt: "A diagram that shows how disposable bearer tokens can be created, used, and refreshed"%} 
 
 Bearer token authentication is simple to set up and use; however, we encourage you to use one of our client libraries if possible. [api.video client libraries](/sdks/api-clients) handle authentication for you, including renewing your token as needed.
 

--- a/templates/documentation/reference/create-and-manage-webhooks.md
+++ b/templates/documentation/reference/create-and-manage-webhooks.md
@@ -22,7 +22,7 @@ api.video provides you the possibility to get a `POST` request to your server th
 
 Here’s how the `video.encoding` webhook’s flow looks like:
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/reference/webhooks/webhooks-dark.svg", light: "/_assets/reference/webhooks/webhooks-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/reference/webhooks/webhooks-dark.svg", light: "/_assets/reference/webhooks/webhooks-light.svg", alt: "A diagram that shows the video.encoding webhook flow"  %}
 
 ## Event properties
 

--- a/templates/documentation/reference/disposable-bearer-token-authentication.md
+++ b/templates/documentation/reference/disposable-bearer-token-authentication.md
@@ -11,7 +11,7 @@ We provide an enhanced security authentication method, which uses a disposable b
 
 ## How it works?
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/reference/disposable-bearer-auth/disposable-bearer-token-dark.svg", light: "/_assets/reference/disposable-bearer-auth/disposable-bearer-token-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/reference/disposable-bearer-auth/disposable-bearer-token-dark.svg", light: "/_assets/reference/disposable-bearer-auth/disposable-bearer-token-light.svg", alt: "A diagram that shows how disposable bearer tokens can be created, used, and refreshed" %}
 
 _Fig. 1_
 

--- a/templates/documentation/vod/add-a-permanent-watermark.md
+++ b/templates/documentation/vod/add-a-permanent-watermark.md
@@ -27,7 +27,7 @@ Watermarks are uploaded separately from videos. You will need to upload the wate
 {% include "_partials/callout.html" kind: "warning", content: content %}
 
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/vod/add-watermarks/watermark-dark.svg", light: "/_assets/vod/add-watermarks/watermark-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/vod/add-watermarks/watermark-dark.svg", light: "/_assets/vod/add-watermarks/watermark-light.svg", alt: "A diagram that shows the process of creating and applying a watermark to a video object" %}
 
 ## Supported Image formats
 

--- a/templates/documentation/vod/backup-and-cold-storage.md
+++ b/templates/documentation/vod/backup-and-cold-storage.md
@@ -16,7 +16,7 @@ With this in mind, we've created ways for you to backup your already transcoded 
 In this section, you'll be able to find guides on how to backup the videos hosted on api.video to your Azure Storage account, Amazon S3 and other storage providers.
 
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/vod/backup-and-cold-storage/backup-and-cold-storage-dark.svg", light: "/_assets/vod/backup-and-cold-storage/backup-and-cold-storage-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/vod/backup-and-cold-storage/backup-and-cold-storage-dark.svg", light: "/_assets/vod/backup-and-cold-storage/backup-and-cold-storage-light.svg", alt: "A diagram that shows the process of backing up videos on different hosting solutions" %}
 
 Below, you will find the scripts that are available for your disposale in order to backup your videos from api.video.
 

--- a/templates/documentation/vod/delegated-upload-tokens.md
+++ b/templates/documentation/vod/delegated-upload-tokens.md
@@ -9,7 +9,7 @@ metadata:
 
 You can upload videos using the traditional two-step process where you create a video container then upload your video into your container. You can also upload a video using a **delegated upload token**. This guide explains how to create, list, retrieve, and delete delegated upload tokens, and how to upload videos with them.
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/vod/upload-tokens/upload-token-dark.svg", light: "/_assets/vod/upload-tokens/upload-token-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/vod/upload-tokens/upload-token-dark.svg", light: "/_assets/vod/upload-tokens/upload-token-light.svg", alt: "A diagram that shows how delegated tokens can be used on the backend and the frontend of your app" %}
 
 In this type of upload, you retrieve a token from the tokens endpoint. You can then directly upload using the token upload endpoint. It's one step, and you don't provide anything except the file. You can update the metadata for the upload later. A benefit of a delegated token is that you define the TTL (time-to-live) value, so it expires only when you need it to. You can always use the token to upload. You can also create delegated tokens for others to use to do uploads.
 

--- a/templates/documentation/vod/video-best-practices.md
+++ b/templates/documentation/vod/video-best-practices.md
@@ -12,7 +12,7 @@ A tutorial for uploading a video with curl can be found [here](https://api.video
 
 A more visual representation can be found below:
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/vod/video-best-practices/create-a-video-dark.svg", light: "/_assets/vod/video-best-practices/create-a-video-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/vod/video-best-practices/create-a-video-dark.svg", light: "/_assets/vod/video-best-practices/create-a-video-light.svg", alt: "A diagram that shows the steps of creating a video object, and uploading a video" %}
 
 {% capture content %}
 **Important things to know**

--- a/templates/documentation/vod/video-object.md
+++ b/templates/documentation/vod/video-object.md
@@ -14,7 +14,7 @@ The video object in reference to api.video is a container of sort (not to be con
 
 Before you [upload a video](/reference/api/Videos#upload-a-video), you need to [create the video object](/reference/api/Videos#create-a-video-object) that will contain the video itself after you upload it. 
 
-{% include "_partials/dark-light-image.md" dark: "/_assets/vod/video-object/create-a-video-dark.svg", light: "/_assets/vod/video-object/create-a-video-light.svg" %}
+{% include "_partials/dark-light-image.md" dark: "/_assets/vod/video-object/create-a-video-dark.svg", light: "/_assets/vod/video-object/create-a-video-light.svg", alt: "A diagram that shows the steps of creating a video object, and uploading a video"  %}
 
 The video object has properties and metadata that you can create and update, below are the attributes that are available for the video object.
 


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205448597201625/1205705919925061).

**Summary**:

- Update `templates\documentation\_partials\dark-light-image.md` by adding `{{ alt }}` to the image alt brackets
- Update all images marked with orange [in this table](https://docs.google.com/spreadsheets/d/1JZv7zxKbgHNbu1-klqMqyni5pKf7mcJjKNosj0lucOM/edit#gid=545335800) on the **Missing alt attributes** tab with image alt descriptions.