### PR TITLE
Fix video limitation in API reference

### DIFF
--- a/templates/documentation/reference/README.md
+++ b/templates/documentation/reference/README.md
@@ -61,10 +61,10 @@ Follow these best practices to secure your API keys:
 
 ## Limitation
 
-Video upload (VOD) is limited in size and minutes. We support video upload for:
+Video upload (VOD) is limited in size and minutes. We support upload for videos that are:
 
-- Videos <10GB in size.
-- Video that are <1440 minutes in length.
+- at most 20 GiB in size.
+- at most 1440 minutes in length.
 
 ## Pagination
 

--- a/templates/nodejs/post-generate.sh
+++ b/templates/nodejs/post-generate.sh
@@ -2,4 +2,4 @@ npm install
 npm run prettier
 cp ../../templates/common-resources/test-assets/* test/data
 cp ../../templates/common-resources/CONTRIBUTING.md ./
-rm post-generate.sh .openapi-generator-ignore
+rm post-generate.sh .openapi-generator-ignore package-lock.json


### PR DESCRIPTION
Quick fix of 10 GiB to 20 GiB in the [API reference](https://docs.api.video/reference#limitation), with some formatting ease.