### PR TITLE
Fix php icon path on API clients page

### DIFF
--- a/templates/documentation/sdks/api-clients/README.md
+++ b/templates/documentation/sdks/api-clients/README.md
@@ -19,7 +19,7 @@ Seamlessly integrate video on demand or live streaming into your current tech st
 
 {% include "_partials/hagrid-item.md" title: "Python", image: "/_assets/icons/sdk_icons/Python.svg", subtitle: "API client",  link: "././apivideo-python-client.md" %}
 
-{% include "_partials/hagrid-item.md" title: "PHP", image: "/_assets/icons/sdk_icons/php.svg", subtitle: "API client",  link: "././apivideo-php-client.md" %}
+{% include "_partials/hagrid-item.md" title: "PHP", image: "/_assets/icons/sdk_icons/Php.svg", subtitle: "API client",  link: "././apivideo-php-client.md" %}
 
 {% include "_partials/hagrid-item.md" title: "Go", image: "/_assets/icons/sdk_icons/Go.svg", subtitle: "API client",  link: "././apivideo-go-client.md" %}
 


### PR DESCRIPTION
Follow-up change for [this Asana task](https://app.asana.com/0/1204370684353095/1205726620215780).

**Summary**:

On the API clients page, I referenced an icon in a partial like this:

```
{% include "_partials/hagrid-item.md" title: "PHP", image: "/_assets/icons/sdk_icons/php.svg", subtitle: "API client",  link: "././apivideo-php-client.md" %}
```

The important part is that the filname is lowercase: `php.svg` while in reality, the filename starts with a capital P: `Php.svg`. The Doctave desktop client renders the icon as expected, but when I published the site, I realized that the icon is not showing up. ⚠️ I've sent the issue to Doctave [on Slack](https://api-video.slack.com/archives/C05DTNR3QDS/p1698087648683989).

Fixing the filename in the path ✅ 