### PR TITLE
Fix typos and style formatting

### DIFF
--- a/templates/documentation/live-streaming/README.md
+++ b/templates/documentation/live-streaming/README.md
@@ -5,22 +5,14 @@ meta:
   description: This page serves as a foundational guide to integrating api.video's solutions for live streaming.
 ---
 
-<p style="font-size: 34px; font-weight: 600; text-align: left;">
-  <span style="font-size: 34px; font-weight: 600; text-align: left; ">
-    What is </span>
-  <span style="font-size: 34px; font-weight: 600; text-align: left; color: #fa5b30; text-decoration: none;">
-    live streaming</span>
-  <span style="font-size: 34px; font-weight: 600; text-align: left; ">?</span>
-</p>
+<p style="font-size: 34px; font-weight: 600; text-align: left">
+  <span style="font-size: 34px; font-weight: 600; text-align: left">
+    What is </span><span style="font-size: 34px; font-weight: 600; text-align: left; color: #fa5b30; text-decoration: none">live streaming</span><span style="font-size: 34px; font-weight: 600; text-align: left">?</span>
 </p>
 
-<p style="opacity: 0.8; font-size: 18px; text-align: left;">
-  <span style="opacity: 0.8; font-size: 18px; text-align: left;"
-    >api.video's live streaming service enables you to stream live video content to any device in real time. 
-    You can create custom video players with api.video's player customization feature, 
-    which empowers you to change the appearance and functionality of the player to suit your needs.</span
-  >
-  <br />
+<p style="opacity: 0.8; font-size: 18px; text-align: left">
+  <span style="opacity: 0.8; font-size: 18px; text-align: left">api.video's live streaming service enables you to stream live video content to any device in real time. You can create custom video players with api.video's player customization feature, which empowers you to change the appearance and functionality of the player to suit your needs.</span>
+  <br/>
 </p>
 
 <div class="section-header"> 

--- a/templates/documentation/vod/README.md
+++ b/templates/documentation/vod/README.md
@@ -5,21 +5,14 @@ meta:
   description: This page serves as a foundational guide to integrating api.video's solutions for video on demand (VOD).
 ---
 
-<p style="font-size: 34px; font-weight: 600; text-align: left;">
-  <span style="font-size: 34px; font-weight: 600; text-align: left; ">
-    What is </span>
-  <span style="font-size: 34px; font-weight: 600; text-align: left; color: #fa5b30; text-decoration: none;">
-    VOD</span>
-  <span style="font-size: 34px; font-weight: 600; text-align: left; ">?</span>
-</p>
+<p style="font-size: 34px; font-weight: 600; text-align: left">
+  <span style="font-size: 34px; font-weight: 600; text-align: left">
+    What is </span><span style="font-size: 34px; font-weight: 600; text-align: left; color: #fa5b30; text-decoration: none">VOD</span><span style="font-size: 34px; font-weight: 600; text-align: left">?</span>
 </p>
 
-<p style="opacity: 0.8; font-size: 18px; text-align: left;">
-  <span style="opacity: 0.8; font-size: 18px; text-align: left;"
-    >api.video's hosting service enables you to upload and store video files, which can then be easily embedded and shared across various devices and platforms. The platform automatically transcodes videos into multiple formats, resolutions, and bitrates, ensuring that the video content can be played on any device with any internet connection.
-api.video's transcoding and delivery is one of the fastest in the market.</span
-  >
-  <br />
+<p style="opacity: 0.8; font-size: 18px; text-align: left">
+  <span style="opacity: 0.8; font-size: 18px; text-align: left">api.video's hosting service enables you to upload and store video files, which can then be easily embedded and shared across various devices and platforms. The platform automatically transcodes videos into multiple formats, resolutions, and bitrates, ensuring that the video content can be played on any device with any internet connection. api.video's transcoding and delivery is one of the fastest on the market.</span>
+  <br/>
 </p>
 
 <div class="section-header"> 


### PR DESCRIPTION
I've cleaned up the style formatting for the titles and intro paragraphs of the [VOD](https://docs.api.video/vod) and [Live streaming](https://docs.api.video/live-streaming) landing pages. 

This should eliminate the unnecessary space in the heading texts:

![image](https://github.com/apivideo/api.video-api-client-generator/assets/51786287/53fae3a3-8fde-4ecf-b925-0eaad8672d06)
![image](https://github.com/apivideo/api.video-api-client-generator/assets/51786287/e355b511-f9b3-47df-8c01-527e4c0302a3)

Also fixed a small typo: in the market --> on the market