### PR TITLE
Update Captions in the API reference

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5736,7 +5736,7 @@ paths:
 
             - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
-            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
+            - This endpoint uses [Symfony](https://symfony.com) to reference the list of supported language tags. You can find the list of supported tags [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php).
           required: true
           style: simple
           explode: false
@@ -5947,7 +5947,7 @@ paths:
 
             - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
-            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
+            - This endpoint uses [Symfony](https://symfony.com) to reference the list of supported language tags. You can find the list of supported tags [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php).
           required: true
           style: simple
           explode: false
@@ -6179,7 +6179,7 @@ paths:
 
             - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
-            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
+            - This endpoint uses [Symfony](https://symfony.com) to reference the list of supported language tags. You can find the list of supported tags [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php).
           required: true
           style: simple
           explode: false
@@ -6375,7 +6375,7 @@ paths:
 
             - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
-            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
+            - This endpoint uses [Symfony](https://symfony.com) to reference the list of supported language tags. You can find the list of supported tags [here](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php).
           required: true
           style: simple
           explode: false

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -11590,10 +11590,20 @@ components:
       properties:
         uri:
           type: string
+          description: 'The unique resource identifier of the uploaded caption.'
+          example: '/videos/vi1111DinStg3oBbN79GklWS/captions/sr-Cyrl'
         src:
           type: string
+          description: 'A direct URL to the uploaded caption file.'
+          example: 'https://cdn.api.video/vod/vi1111DinStg3oBbN79GklWS/captions/sr-Cyrl.vtt'
         srclang:
           type: string
+          description: 'Indicates the language of the uploaded caption file using IETF language tags.'
+          example: 'sr-Cyrl'
+        languageName:
+          type: string
+          description: 'Returns the native name of the caption language in UTF-8 encoding.'
+          example: 'српски (ћирилица)'
         default:
           type: boolean
           description: 'Whether you will have subtitles or not. True for yes you will have subtitles, false for no you will not have subtitles.'

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5732,10 +5732,11 @@ paths:
         - name: language
           in: path
           description: |-
-            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+            A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
-            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
+            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
           required: true
           style: simple
           explode: false
@@ -5942,10 +5943,11 @@ paths:
         - name: language
           in: path
           description: |-
-            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+            A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
-            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
+            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
           required: true
           style: simple
           explode: false
@@ -6173,10 +6175,11 @@ paths:
         - name: language
           in: path
           description: |-
-            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+            A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
-            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
+            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
           required: true
           style: simple
           explode: false
@@ -6368,10 +6371,11 @@ paths:
         - name: language
           in: path
           description: |-
-            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+            A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
-            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - This parameter **only accepts dashes for separators**, for example `fr-CA`. If you use a different separator in your request, the API returns an error.
             - When the value in your request does not match any covered language, the API returns an error.
+            - This endpoint uses (Symfony)[https://symfony.com/] to reference the list of supported language tags. You can find the list of supported tags (here)[https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Intl/Resources/data/locales/meta.php].
           required: true
           style: simple
           explode: false

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5756,7 +5756,32 @@ paths:
                     uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
                     src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
                     srclang: en
+                    languageName: English
                     default: false
+        '400':
+          description: Bad request error
+          content:
+            application/json:
+              schema:
+                title: Bad request error
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                Invalid language formatting:
+                  description: This error occurs when the language tag you provided contains characters other than letters and dashes.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute must contain only letters and dashes (for example "fr", "fr-BE").
+                    name: language
+                Invalid language:
+                  description: This error occurs when the language tag you provided does not match any supported language.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute is not valid.
+                    name: language
         '404':
           description: Not Found
           content:
@@ -5973,13 +5998,32 @@ paths:
                     uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
                     src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
                     srclang: en
+                    languageName: English
                     default: false
         '400':
-          description: Bad Request
+          description: Bad request error
           content:
             application/json:
               schema:
+                title: Bad request error
                 $ref: '#/components/schemas/bad-request'
+              examples:
+                Invalid language formatting:
+                  description: This error occurs when the language tag you provided contains characters other than letters and dashes.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute must contain only letters and dashes (for example "fr", "fr-BE").
+                    name: language
+                Invalid language:
+                  description: This error occurs when the language tag you provided does not match any supported language.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute is not valid.
+                    name: language
         '404':
           description: Not Found
           content:
@@ -6189,6 +6233,30 @@ paths:
       responses:
         '204':
           description: No Content
+        '400':
+          description: Bad request error
+          content:
+            application/json:
+              schema:
+                title: Bad request error
+                $ref: '#/components/schemas/bad-request'
+              examples:
+                Invalid language formatting:
+                  description: This error occurs when the language tag you provided contains characters other than letters and dashes.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute must contain only letters and dashes (for example "fr", "fr-BE").
+                    name: language
+                Invalid language:
+                  description: This error occurs when the language tag you provided does not match any supported language.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute is not valid.
+                    name: language
         '404':
           description: Not Found
           content:
@@ -6401,22 +6469,32 @@ paths:
                     uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
                     src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
                     srclang: en
+                    languageName: English
                     default: true
         '400':
-          description: Bad Request
+          description: Bad request error
           content:
             application/json:
               schema:
+                title: Bad request error
                 $ref: '#/components/schemas/bad-request'
               examples:
-                response:
+                Invalid language formatting:
+                  description: This error occurs when the language tag you provided contains characters other than letters and dashes.
                   value:
-                    type: string (required)
-                    title: string (required)
-                    name: string (required)
-                    status: integer (required)
-                    problems:
-                      - null
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute must contain only letters and dashes (for example "fr", "fr-BE").
+                    name: language
+                Invalid language:
+                  description: This error occurs when the language tag you provided does not match any supported language.
+                  value:
+                    type: https://docs.api.video/reference/invalid-attribute
+                    title: An attribute is invalid.
+                    status: 400
+                    detail: The "language" attribute is not valid.
+                    name: language
         '404':
           description: Not Found
           content:
@@ -6642,10 +6720,12 @@ paths:
                       - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/en
                         src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/en.vtt'
                         srclang: en
+                        languageName: English
                         default: false
                       - uri: /videos/vi3N6cDinStg3oBbN79GklWS/captions/fr
                         src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt'
                         srclang: fr
+                        languageName: Française
                         default: false
                     pagination:
                       currentPage: 1

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5788,7 +5788,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                       
                   videoId := "vi4k0jvEUuaTdRAEjQ4Prklg" // string | The unique identifier for the video you want captions for.
-                  language := "en" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  language := "en" // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   
                   res, err := client.Captions.Get(videoId, language)
@@ -5809,7 +5809,7 @@ paths:
               const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
 
               const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
-              const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+              const language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
               const caption = await client.captions.get(videoId, language);
           - language: python
@@ -5828,7 +5828,7 @@ paths:
                   # Create an instance of the API class
                   api_instance = captions_api.CaptionsApi(api_client)
                   video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
-                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  language = "en" # str | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   # example passing only required values which don't have defaults set
                   try:
@@ -5857,7 +5857,7 @@ paths:
                   CaptionsApi apiInstance = client.captions();
                   
                   String videoId = "vi4k0jvEUuaTdRAEjQ4Prklg"; // The unique identifier for the video you want captions for.
-                  String language = "en"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  String language = "en"; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   try {
                     Caption result = apiInstance.get(videoId, language);
@@ -5891,7 +5891,7 @@ paths:
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
                           var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
-                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                          var language = en;  // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                           var apiCaptionsInstance = apiInstance.Captions();
                           try
                           {
@@ -5917,7 +5917,7 @@ paths:
               require __DIR__ . '/vendor/autoload.php';
 
               $videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want captions for.
-              $language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+              $language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
               $client->captions()->get($videoId, $language); 
           - language: swift
@@ -6011,7 +6011,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                       
                   videoId := "vi4k0jvEUuaTdRAEjQ4Prklg" // string | The unique identifier for the video you want to add a caption to.
-                  language := "en" // string | A valid BCP 47 language representation.
+                  language := "en" // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                   file := os.NewFile(1234, "some_file") // *os.File | The video text track (VTT) you want to upload.
 
                   
@@ -6036,7 +6036,7 @@ paths:
               const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
 
               const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to add a caption to.
-              const language = 'en'; // A valid BCP 47 language representation.
+              const language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
               const file = './en.vtt'; // The video text track (VTT) you want to upload.
 
               const caption = await client.captions.upload(videoId, language, file); 
@@ -6057,7 +6057,7 @@ paths:
                   # Create an instance of the API class
                   api_instance = captions_api.CaptionsApi(api_client)
                   video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to add a caption to.
-                  language = "en" # str | A valid BCP 47 language representation.
+                  language = "en" # str | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                   file = open('/path/to/file', 'rb') # file_type | The video text track (VTT) you want to upload.
 
                   # example passing only required values which don't have defaults set
@@ -6087,7 +6087,7 @@ paths:
                   CaptionsApi apiInstance = client.captions();
                   
                   String videoId = "vi4k0jvEUuaTdRAEjQ4Prklg"; // The unique identifier for the video you want captions for.
-                  String language = "en"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  String language = "en"; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   try {
                     Caption result = apiInstance.get(videoId, language);
@@ -6121,7 +6121,7 @@ paths:
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
                           var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to add a caption to.
-                          var language = en;  // string | A valid BCP 47 language representation.
+                          var language = en;  // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                           var file = BINARY_DATA_HERE;  // System.IO.Stream | The video text track (VTT) you want to upload.
                           var apiCaptionsInstance = apiInstance.Captions();
                           try
@@ -6148,7 +6148,7 @@ paths:
               require __DIR__ . '/vendor/autoload.php';
 
               $videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to add a caption to.
-              $language = 'en'; // A valid BCP 47 language representation.
+              $language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
               $file = new SplFileObject(__DIR__ . '/en.vtt'); // The video text track (VTT) you want to upload.
 
               $caption = $client->captions()->upload($videoId, $language, $file); 
@@ -6220,7 +6220,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                       
                   videoId := "vi4k0jvEUuaTdRAEjQ4Prklgc" // string | The unique identifier for the video you want to delete a caption from.
-                  language := "en" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  language := "en" // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   
                   err := client.Captions.Delete(videoId, language)
@@ -6238,7 +6238,7 @@ paths:
               const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
 
               const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklgc'; // The unique identifier for the video you want to delete a caption from.
-              const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              const language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
               await client.captions.delete(videoId, language);
                
@@ -6257,7 +6257,7 @@ paths:
                   # Create an instance of the API class
                   api_instance = captions_api.CaptionsApi(api_client)
                   video_id = "vi4k0jvEUuaTdRAEjQ4Prklgc" # str | The unique identifier for the video you want to delete a caption from.
-                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  language = "en" # str | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   # example passing only required values which don't have defaults set
                   try:
@@ -6285,7 +6285,7 @@ paths:
                   CaptionsApi apiInstance = client.captions();
                   
                   String videoId = "vi4k0jvEUuaTdRAEjQ4Prklgc"; // The unique identifier for the video you want to delete a caption from.
-                  String language = "en"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  String language = "en"; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   try {
                     apiInstance.delete(videoId, language);
@@ -6318,7 +6318,7 @@ paths:
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
                           var videoId = vi4k0jvEUuaTdRAEjQ4Prklgc;  // string | The unique identifier for the video you want to delete a caption from.
-                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var language = en;  // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                           var apiCaptionsInstance = apiInstance.Captions();
                           try
                           {
@@ -6343,7 +6343,7 @@ paths:
               require __DIR__ . '/vendor/autoload.php';
 
               $videoId = 'vi4k0jvEUuaTdRAEjQ4Prklgc'; // The unique identifier for the video you want to delete a caption from.
-              $language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              $language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
               $client->captions()->delete($videoId, $language); 
           - language: swift
@@ -6455,7 +6455,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                       
                   videoId := "vi4k0jvEUuaTdRAEjQ4Prklg" // string | The unique identifier for the video you want to have automatic captions for.
-                  language := "en" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  language := "en" // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                   captionsUpdatePayload := *apivideosdk.NewCaptionsUpdatePayload() // CaptionsUpdatePayload | 
 
                   
@@ -6477,7 +6477,7 @@ paths:
               const client = new ApiVideoClient({ apiKey: "YOUR_API_KEY" });
 
               const videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to have automatic captions for.
-              const language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              const language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
               const captionsUpdatePayload = {
                 _default: true,
               }; 
@@ -6502,7 +6502,7 @@ paths:
                   # Create an instance of the API class
                   api_instance = captions_api.CaptionsApi(api_client)
                   video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want to have automatic captions for.
-                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  language = "en" # str | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                   captions_update_payload = CaptionsUpdatePayload(
                       default=True,
                   ) # CaptionsUpdatePayload | 
@@ -6535,7 +6535,7 @@ paths:
                   CaptionsApi apiInstance = client.captions();
                   
                   String videoId = "vi4k0jvEUuaTdRAEjQ4Prklg"; // The unique identifier for the video you want to have automatic captions for.
-                  String language = "en"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                  String language = "en"; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                   CaptionsUpdatePayload captionsUpdatePayload = new CaptionsUpdatePayload(); // 
                   captionsUpdatePayload.setDefault(); // 
 
@@ -6572,7 +6572,7 @@ paths:
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
                           var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want to have automatic captions for.
-                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+                          var language = en;  // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                           var captionsUpdatePayload = new CaptionsUpdatePayload(); // CaptionsUpdatePayload | 
                           var apiCaptionsInstance = apiInstance.Captions();
                           try
@@ -6599,7 +6599,7 @@ paths:
               require __DIR__ . '/vendor/autoload.php';
 
               $videoId = 'vi4k0jvEUuaTdRAEjQ4Prklg'; // The unique identifier for the video you want to have automatic captions for.
-              $language = 'en'; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.
+              $language = 'en'; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
               $captionsUpdatePayload = (new \ApiVideo\Client\Model\CaptionsUpdatePayload())
                   ->setDefault(true);
@@ -6693,7 +6693,7 @@ paths:
                   // client := apivideosdk.SandboxClientBuilder("YOUR_SANDBOX_API_KEY").Build()
                       
                   videoId := "vi4k0jvEUuaTdRAEjQ4Prklg" // string | The unique identifier for the video you want captions for.
-                  language := "en" // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  language := "en" // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   
                   res, err := client.Captions.Get(videoId, language)
@@ -6734,7 +6734,7 @@ paths:
                   # Create an instance of the API class
                   api_instance = captions_api.CaptionsApi(api_client)
                   video_id = "vi4k0jvEUuaTdRAEjQ4Prklg" # str | The unique identifier for the video you want captions for.
-                  language = "en" # str | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  language = "en" # str | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   # example passing only required values which don't have defaults set
                   try:
@@ -6763,7 +6763,7 @@ paths:
                   CaptionsApi apiInstance = client.captions();
                   
                   String videoId = "vi4k0jvEUuaTdRAEjQ4Prklg"; // The unique identifier for the video you want captions for.
-                  String language = "en"; // A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                  String language = "en"; // A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
 
                   try {
                     Caption result = apiInstance.get(videoId, language);
@@ -6797,7 +6797,7 @@ paths:
                           var apiInstance = new ApiVideoClient(apiKey,basePath);
 
                           var videoId = vi4k0jvEUuaTdRAEjQ4Prklg;  // string | The unique identifier for the video you want captions for.
-                          var language = en;  // string | A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation
+                          var language = en;  // string | A valid language identifier using IETF language tags. You can use primary subtags like `en` (English), extended subtags like `fr-CA` (French, Canada), or region subtags like `zh-Hans-CN` (Simplified Chinese used in the PRC).
                           var apiCaptionsInstance = apiInstance.Captions();
                           try
                           {

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -5731,7 +5731,11 @@ paths:
           example: vi4k0jvEUuaTdRAEjQ4Prklg
         - name: language
           in: path
-          description: 'A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation'
+          description: |-
+            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+
+            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - When the value in your request does not match any covered language, the API returns an error.
           required: true
           style: simple
           explode: false
@@ -5937,7 +5941,11 @@ paths:
           example: vi4k0jvEUuaTdRAEjQ4Prklg
         - name: language
           in: path
-          description: A valid BCP 47 language representation.
+          description: |-
+            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+
+            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - When the value in your request does not match any covered language, the API returns an error.
           required: true
           style: simple
           explode: false
@@ -6164,7 +6172,11 @@ paths:
           example: vi4k0jvEUuaTdRAEjQ4Prklgc
         - name: language
           in: path
-          description: 'A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.'
+          description: |-
+            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+
+            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - When the value in your request does not match any covered language, the API returns an error.
           required: true
           style: simple
           explode: false
@@ -6355,7 +6367,11 @@ paths:
           example: vi4k0jvEUuaTdRAEjQ4Prklg
         - name: language
           in: path
-          description: 'A valid [BCP 47](https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers) language representation.'
+          description: |-
+            A valid language identifier using (IETF language tags)[https://datatracker.ietf.org/doc/rfc5646]. You can use primary subtags like `en` (English), extended subtags like `fr-ca` (French, Canada), or region subtags like `zh-yue-hk` (Cantonese, as used in Hong Kong SAR).
+
+            - This parameter accepts lowercase letters with dashes for separators, for example `fr-ca`.
+            - When the value in your request does not match any covered language, the API returns an error.
           required: true
           style: simple
           explode: false


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1204307844224163/1206003116770297).

**Summary**: 

* Updated the description for the `language` parameter across all captions endpoints' request schemas
* Updated the code snippets where the `language` parameter is explained
* Updated the response schemas for all captions endpoints to contain the new `languageName` field
* Added `400` response schemas and response examples to all captions endpoints
* Added `languageName` to all example responses across captions endpoints
* Added descriptions to the `caption` response object schema

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206003116770301