### PR TITLE
Update get live streams sortby attribute

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4042,12 +4042,19 @@ paths:
           example: My Video
         - name: sortBy
           in: query
-          description: 'Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.'
+          description: |
+            Enables you to sort live stream results. Allowed attributes: `name`, `createdAt`, `updatedAt`.
+            `name` - the name of the live stream.
+            `createdAt` - the time a live stream was created using.
+            `updatedAt` - the time a live stream was last updated.
+            
+            When using `createdAt` or `updatedAt`, the API sorts the results based on the ISO-8601 time format.
           required: false
           style: form
           explode: true
           schema:
             type: string
+            enum: [name, createdAt, updatedAt]
           example: createdAt
         - name: sortOrder
           in: query

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4045,7 +4045,7 @@ paths:
           description: |
             Enables you to sort live stream results. Allowed attributes: `name`, `createdAt`, `updatedAt`.
             `name` - the name of the live stream.
-            `createdAt` - the time a live stream was created using.
+            `createdAt` - the time a live stream was created.
             `updatedAt` - the time a live stream was last updated.
             
             When using `createdAt` or `updatedAt`, the API sorts the results based on the ISO-8601 time format.


### PR DESCRIPTION
Changes are for [this Asana task](https://app.asana.com/0/1205634133195403/1206211746134025).

Slack thread: https://api-video.slack.com/archives/C04H2LRGF29/p1703066315590759

**Summary**: 

The `sortBy` attribute for `GET /live-streams` needs some updates:
- add `createdAt`, `updatedAt`, and `name` as enums
- format description (code formatting, line breaks)
- remove `publishedAt` from description