### PR TITLE
Update sortby in code snippets

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -4162,7 +4162,7 @@ paths:
                     
                     req.StreamKey("30087931-229e-42cf-b5f9-e91bcc1f7332") // string | The unique stream key that allows you to stream videos.
                     req.Name("My Video") // string | You can filter live streams by their name or a part of their name.
-                    req.SortBy("createdAt") // string | Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
+                    req.SortBy("createdAt") // string | Enables you to sort live stream results. Allowed attributes: `name`, `createdAt`, `updatedAt`.
                     req.SortOrder("desc") // string | Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
                     req.CurrentPage(int32(2)) // int32 | Choose the number of search results to return per page. Minimum value: 1 (default to 1)
                     req.PageSize(int32(30)) // int32 | Results per page. Allowed values 1-100, default is 25. (default to 25)
@@ -4249,7 +4249,7 @@ paths:
                   
                   String streamKey = "30087931-229e-42cf-b5f9-e91bcc1f7332"; // The unique stream key that allows you to stream videos.
                   String name = "My Video"; // You can filter live streams by their name or a part of their name.
-                  String sortBy = "createdAt"; // Allowed: createdAt, publishedAt, name. createdAt - the time a livestream was created using the specified streamKey. publishedAt - the time a livestream was published using the specified streamKey. name - the name of the livestream. If you choose one of the time based options, the time is presented in ISO-8601 format.
+                  String sortBy = "createdAt"; // Enables you to sort live stream results. Allowed attributes: `name`, `createdAt`, `updatedAt`.
                   String sortOrder = "desc"; // Allowed: asc, desc. Ascending for date and time means that earlier values precede later ones. Descending means that later values preced earlier ones. For title, it is 0-9 and A-Z ascending and Z-A, 9-0 descending.
                   Integer currentPage = 1; // Choose the number of search results to return per page. Minimum value: 1
                   Integer pageSize = 25; // Results per page. Allowed values 1-100, default is 25.


### PR DESCRIPTION
Follow-up for [this Asana task](https://app.asana.com/0/1205634133195403/1206211746134025).

Slack thread: https://api-video.slack.com/archives/C04H2LRGF29/p1703066315590759

**Summary**:

- removed `publishedAt` from `sortBy` parameter description, and updated wording for the Go and Java code snippets for `GET /live-streams`