### PR TITLE
Update VideoStatusIngest enum descriptions

### DIFF
--- a/config/android.yaml
+++ b/config/android.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.5.5 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.5.4 (2024-01-08):
     - Upgrade dependencies, gradle and Kotlin
   - 1.5.3 (2023-12-14):

--- a/config/csharp.yaml
+++ b/config/csharp.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.1 (2024-02-19): 
+    - Update VideoStatusIngest enum
   - 1.3.0 (2023-06-28):
     - Introducing new live streams restream feature
     - Introducing new analytics endpoints

--- a/config/go.yaml
+++ b/config/go.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.1 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.3.0 (2023-06-28):
     - Introducing new live streams restream feature
     - Introducing new analytics endpoints

--- a/config/java.yaml
+++ b/config/java.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.2 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.3.1 (2023-08-10):
     - Fix upload with upload token and video id when video is smaller than chunk size
   - 1.3.0 (2023-06-28):

--- a/config/nodejs.yaml
+++ b/config/nodejs.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 2.5.6 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 2.5.5 (2023-12-19):
     - Fix documentation links
   - 2.5.4 (2023-08-21):

--- a/config/php.yaml
+++ b/config/php.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.2 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.3.1 (2023-06-28):
     - Added missing AuthenticationFailedException
   - 1.3.0 (2023-06-28):

--- a/config/python.yaml
+++ b/config/python.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.1 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.3.0 (2023-06-28):
     - Introducing new live streams restream feature
     - Introducing new analytics endpoints

--- a/config/swift5.yaml
+++ b/config/swift5.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.2.2 (2024-02-19):
+    - Update VideoStatusIngest enum
   - 1.2.1 (2023-08-25):
     - Fix progressive upload with upload token and video id
     - Use pascal case for enums

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -12859,12 +12859,18 @@ components:
       properties:
         status:
           type: string
-          description: There are three possible ingest statuses. missing - you are missing information required to ingest the video. uploading - the video is in the process of being uploaded. uploaded - the video is ready for use.
+          description:  |
+            There are four possible statuses depending on how you provide a video file:
+            - `uploading` - the API is gathering the video source file from an upload.
+            - `uploaded` - the video file is fully uploaded.
+            - `ingesting` - the API is gathering the video source file from either a URL, or from cloning.
+            - `ingested` - the video file is fully stored.
           example: uploaded
           enum:
-            - missing
             - uploading
             - uploaded
+            - ingesting
+            - ingested
         filesize:
           type: integer
           description: The size of your file in bytes.


### PR DESCRIPTION
Context: [Slack](https://api-video.slack.com/archives/C04H2LRGF29/p1708077902670559)

Changes:

* removed `missing` enum
* added `ingesting` and `ingested` enums
* updated descriptions and formatting