### PR TITLE
fix(php): Fix date formatting in ObjectSerializer

### DIFF
--- a/templates/php/src/ObjectSerializer.mustache
+++ b/templates/php/src/ObjectSerializer.mustache
@@ -45,7 +45,9 @@ class ObjectSerializer
         }
 
         if ($data instanceof \DateTime) {
-            return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
+            return ($type === 'date' || $format === 'date')
+                ? $data->format('Y-m-d')
+                : $data->format(self::$dateTimeFormat);
         }
 
         if (is_array($data)) {


### PR DESCRIPTION
**Problem** :
Function `getVideosPlays()` from Analytics PHP Api throw 400 error :
`ApiVideo\Client\Exception\HttpException: HTTP 400 returned. {"type":"https:\/\/docs.api.video\/reference\/request-invalid-query-parameter","title":"A query parameter is invalid.","status":400,"detail":"This value is not a valid date.","name":"from"}`

Code :
`$dateFrom = (new DateTime())->sub(new DateInterval('P1D'));
 $apiVideoSessions = $this->client->analytics()->getVideosPlays($dateFrom, 'videoId');`

**Because :** 
In src/Api/AnalyticsApi.php : 

- line 103 : `$queryParams['from'] = ObjectSerializer::sanitizeForSerialization($from, 'date');`
- line 104 : `$queryParams['to'] = ObjectSerializer::sanitizeForSerialization($to, 'date');`
- line 209 : `$queryParams['from'] = ObjectSerializer::sanitizeForSerialization($from, 'date');`
- line 214 : `$queryParams['to'] = ObjectSerializer::sanitizeForSerialization($to, 'date');`

Second parameter of ObjectSerializer::sanitizeForSerialization must be $type and not $format.

In `ObjectSerializer::sanitizeForSerialization($data, $type = null, $format = null)` : 
`if ($data instanceof \DateTime) {
     return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
}`

**Fix :**
`if ($data instanceof \DateTime) {
     return ($type === 'date' || $format === 'date')
          ? $data->format('Y-m-d')
          : $data->format(self::$dateTimeFormat);
}`