### PR TITLE
fix(java): android: hash token and video id for workmanager API

### DIFF
--- a/config/android-uploader.yaml
+++ b/config/android-uploader.yaml
@@ -169,5 +169,8 @@ files:
   android/work/DataExtensions.mustache:
     folder: src/main/java/video/api/uploader/api/work
     destinationFilename: DataExtensions.kt
+  android/work/utils/Hash.mustache:
+    folder: src/main/java/video/api/uploader/api/work/utils
+    destinationFilename: Hash.kt
   consumer-rules.mustache:
     destinationFilename: consumer-rules.pro

--- a/config/android.yaml
+++ b/config/android.yaml
@@ -197,5 +197,8 @@ files:
   android/work/DataExtensions.mustache:
     folder: src/main/java/video/api/client/api/work
     destinationFilename: DataExtensions.kt
+  android/work/utils/Hash.mustache:
+    folder: src/main/java/video/api/uploader/api/work/utils
+    destinationFilename: Hash.kt
   consumer-rules.mustache:
     destinationFilename: consumer-rules.pro

--- a/templates/java/android/work/UploadWorkerHelper.mustache
+++ b/templates/java/android/work/UploadWorkerHelper.mustache
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import {{invokerPackage}}.upload.IProgressiveUploadSession
 import {{invokerPackage}}.work.UploadWorkerHelper.upload
 import {{invokerPackage}}.work.stores.ProgressiveUploadSessionStore
+import {{invokerPackage}}.work.utils.md5
 import {{invokerPackage}}.work.workers.ProgressiveUploadWorker
 import {{invokerPackage}}.work.workers.UploadWorker
 import java.io.File
@@ -418,7 +419,7 @@ object UploadWorkerHelper {
      * @return The tag
      */
     fun getTagForVideoId(videoId: String): String {
-        return "($PREFIX_VIDEO_ID$videoId)"
+        return "($PREFIX_VIDEO_ID${videoId.md5()})"
     }
 
     /**
@@ -428,7 +429,7 @@ object UploadWorkerHelper {
      * @return The tag
      */
     fun getTagForUploadToken(token: String): String {
-        return "($PREFIX_TOKEN$token)"
+        return "($PREFIX_TOKEN${token.md5()})"
     }
 
     private const val PREFIX_VIDEO_ID = "videoId="

--- a/templates/java/android/work/utils/Hash.mustache
+++ b/templates/java/android/work/utils/Hash.mustache
@@ -1,0 +1,14 @@
+package {{invokerPackage}}.work.utils
+
+import java.security.MessageDigest
+
+fun String.md5(): String {
+    return hashString(this, "MD5")
+}
+
+private fun hashString(input: String, algorithm: String): String {
+    return MessageDigest
+        .getInstance(algorithm)
+        .digest(input.toByteArray())
+        .fold("") { str, it -> str + "%02x".format(it) }
+}


### PR DESCRIPTION
The upload token and the video id appear in clear text in a log from the WorkManager. It is unlikely to happen but someone can intercept them and it could lead to a security leak.

The tags are used to filter the Work. We don't need the real value in this case, a hash would suffice.

This is the purpose of this PR.

