### PR TITLE
fix(swift5): fix compile error from Alamofire 5.10

### DIFF
--- a/templates/swift5/libraries/alamofire/AlamofireImplementations.mustache
+++ b/templates/swift5/libraries/alamofire/AlamofireImplementations.mustache
@@ -413,6 +413,8 @@ extension JSONDataEncoding: ParameterEncoding {
     public func encode(_ urlRequest: URLRequestConvertible, with parameters: Parameters?) throws -> URLRequest {
         let urlRequest = try urlRequest.asURLRequest()
 
-        return encode(urlRequest, with: parameters)
+        // Alamofire 5.10 changed type of Parameters so that it is no longer equivalent to [String: Any]
+        // cast this type so that the call to encode is not recursive
+        return encode(urlRequest, with: parameters as [String: Any]?)
     }
 }


### PR DESCRIPTION
Original commit is: https://github.com/OpenAPITools/openapi-generator/commit/1248d7a103dddf918978c5b688f67f26bd5aaf1c#diff-9867f46419733e8b0ff1e4e515000c7fb28ad36ca6d9634e793835a13661ef2eR411
Issue reported: https://github.com/apivideo/api.video-swift-client/issues/95