### PR TITLE
Update Summary endpoints

### DIFF
--- a/apivideo-generator/src/main/java/video/api/client/generator/Java.java
+++ b/apivideo-generator/src/main/java/video/api/client/generator/Java.java
@@ -75,10 +75,12 @@ public class Java extends JavaClientCodegen {
                         .flatMap(p -> p.vars.stream())
                         .forEach(v -> {
                             if (v.dataType.equals("List<String>")) {
-                                v.example = "Arrays.asList(" + v.example
-                                        .replaceAll("\\[", "")
-                                        .replaceAll("\\]", "")
-                                        .replaceAll("\\\\\"", "\"") + ")";
+                                if(v.example != null) {
+                                    v.example = "Arrays.asList(" + v.example
+                                            .replaceAll("\\[", "")
+                                            .replaceAll("\\]", "")
+                                            .replaceAll("\\\\\"", "\"") + ")";
+                                }
                             } else if (v.isArray) {
                                 v.example = "Collections.<" + v.items.dataType + ">emptyList()";
                             } else if (v.isString) {

--- a/config/android.yaml
+++ b/config/android.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.6.7 (2024-11-06):
+      - AI summary updates
   - 1.6.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.6.5 (2024-10-21):

--- a/config/csharp.yaml
+++ b/config/csharp.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.6.7 (2024-11-06):
+      - AI summary updates
   - 1.6.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.6.5 (2024-10-21):

--- a/config/go.yaml
+++ b/config/go.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.4.7 (2024-11-06):
+      - AI summary updates
   - 1.4.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.4.5 (2024-10-21):

--- a/config/java.yaml
+++ b/config/java.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.4.7 (2024-11-06):
+      - AI summary updates
   - 1.4.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.4.5 (2024-10-21):

--- a/config/nodejs.yaml
+++ b/config/nodejs.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 2.6.8 (2024-11-06):
+      - AI summary updates
   - 2.6.7 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 2.6.6 (2024-10-21):

--- a/config/php.yaml
+++ b/config/php.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.4.7 (2024-11-06):
+      - AI summary updates
   - 1.4.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.4.5 (2024-10-21):

--- a/config/python.yaml
+++ b/config/python.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.4.7 (2024-11-06):
+      - AI summary updates
   - 1.4.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.4.5 (2024-10-21):

--- a/config/swift5.yaml
+++ b/config/swift5.yaml
@@ -1,4 +1,6 @@
 changelog:
+  - 1.3.7 (2024-11-06):
+      - AI summary updates
   - 1.3.6 (2024-11-04):
       - Analytics updates (ccv, views, ...)
   - 1.3.5 (2024-10-21):

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -1049,10 +1049,10 @@ paths:
       tags:
         - Summaries
       summary: Generate video summary
-      description: Generate a title, abstract, and key takeaways for a video.
+      description: Generate an abstract and key takeaways for a video.
       x-client-action: create
       x-client-description:
-        default: 'Generate a title, abstract, and key takeaways for a video.'
+        default: 'Generate an abstract and key takeaways for a video.'
       operationId: POST_summaries
       security:
         - apiKey: []
@@ -1350,10 +1350,10 @@ paths:
       tags:
         - Summaries
       summary: Update summary details
-      description: Update details for a summary. Note that this operation is only allowed for summary objects where `sourceStatus` is `missing`.
+      description: Update details for a summary.
       x-client-action: update
       x-client-description:
-        default: 'Update details for a summary. Note that this operation is only allowed for summary objects where `sourceStatus` is `missing`.'
+        default: 'Update details for a summary.'
       operationId: PATCH_summaries-summaryId-source
       parameters:
         - name: summaryId
@@ -1391,32 +1391,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/summary-source'
-        '409':
-          headers:
-            X-RateLimit-Limit:
-              schema:
-                type: integer
-              description: The request limit per minute.
-            X-RateLimit-Remaining:
-              schema:
-                type: integer
-              description: The number of available requests left for the current time window.
-            X-RateLimit-Retry-After:
-              schema:
-                type: integer
-              description: The number of seconds left until the current rate limit window resets.
-          description: Conflict
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/conflict-error'
-              examples:
-                Summary already exists:
-                  value:
-                    type: https://docs.api.video/reference/summary-already-exists
-                    title: A summary already exists or is being created on this video.
-                    status: 409
-                    detail: You can delete the existing summary and generate a new one.
   '/videos/{videoId}/source':
     post:
       tags:
@@ -15982,6 +15956,10 @@ components:
         playerId: pl45KFKdlddgk654dspkze
         language: en
         transcript: true
+        transcriptSummary: true
+        transcriptSummaryAttributes:
+          - abstract
+          - takeaways
         tags:
           - maths
           - string theory
@@ -16071,6 +16049,12 @@ components:
             - When `true`, the API generates a summary for the video, based on the transcription.
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
+        transcriptSummaryAttributes:
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          type: array
+          items:
+            type: string
+            enum: [abstract, takeaways]
       required:
         - title
     summary-creation-payload:
@@ -16092,13 +16076,15 @@ components:
 
             In this case, `sourceStatus` will return `missing`, and you have to manually add a summary using the `PATCH /summaries/{summaryId}/source` endpoint operation.
           example: auto
+        attributes:
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          type: array
+          items:
+            type: string
+            enum: [abstract, takeaways]
     summary-update-payload:
       type: object
       properties:
-        title:
-          type: string
-          description: A video title, based on the contents of the video.
-          example: 'A short lecture on quantum theory'
         abstract:
           type: string
           description: A short outline of the contents of the video.
@@ -16134,10 +16120,6 @@ components:
     summary-source:
       type: object
       properties:
-        title:
-          type: string
-          description: A video title, based on the contents of the video.
-          example: 'A short lecture on quantum theory'
         abstract:
           type: string
           description: A short outline of the contents of the video. The length of an `abstract` depends on the amount of content in a video that can be transcribed. The API condenses the contents into minimum 20, maximum 300 words.
@@ -16313,6 +16295,12 @@ components:
             - When `true`, the API generates a summary for the video, based on the transcription.
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
+        transcriptSummaryAttributes:
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          type: array
+          items:
+            type: string
+            enum: [abstract, takeaways]
       example:
         playerId: pl45KFKdlddgk654dspkze
         title: String theory
@@ -16321,6 +16309,9 @@ components:
         language: 'en'
         transcript: true
         transcriptSummary: true
+        transcriptSummaryAttributes:
+          - abstract
+          - takeaways
         panoramic: false
         mp4Support: true
         tags:

--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -1390,7 +1390,33 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/summary-source'
+                $ref: '#/components/schemas/summary-source'        
+        '409':
+          headers:
+            X-RateLimit-Limit:
+              schema:
+                type: integer
+              description: The request limit per minute.
+            X-RateLimit-Remaining:
+              schema:
+                type: integer
+              description: The number of available requests left for the current time window.
+            X-RateLimit-Retry-After:
+              schema:
+                type: integer
+              description: The number of seconds left until the current rate limit window resets.
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/conflict-error'
+              examples:
+                Summary generation still in progress:
+                  value:
+                    type: https://docs.api.video/reference/summary-already-exists
+                    title: A summary already exists or is being created on this video.
+                    status: 409
+                    detail: You can delete the existing summary and generate a new one.
   '/videos/{videoId}/source':
     post:
       tags:

--- a/templates/php/README.mustache
+++ b/templates/php/README.mustache
@@ -180,7 +180,7 @@ $ BASE_URI="" API_KEY="..." vendor/bin/phpunit
 ```
 
 
-## Have you gotten use from this API client?
+## Have you gotten use from this API client? 
 
 Please take a moment to leave a star on the client ⭐
 


### PR DESCRIPTION
Changes are for these Asana tasks:

- [Remove summary title](https://app.asana.com/0/1205386992201973/1208697246097961)
- [Select summary attributes individually](https://app.asana.com/0/1205386992201973/1208647488270061)

**Summary** 🤖

- Remove mentions of the `title` attribute of summary sources
- Add new parameters that enable summary creation with individual attributes:
   - `transcriptSummaryAttributes`
   - `attributes`
- Update description of `409` error for `PATCH /summaries/{summaryId}/source`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208702543603268