### PR TITLE
Add missing description

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -16076,7 +16076,7 @@ components:
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
         transcriptSummaryAttributes:
-          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes. The possible values are `abstract` and `takeaways`.
           type: array
           items:
             type: string
@@ -16103,7 +16103,7 @@ components:
             In this case, `sourceStatus` will return `missing`, and you have to manually add a summary using the `PATCH /summaries/{summaryId}/source` endpoint operation.
           example: auto
         attributes:
-          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes. The possible values are `abstract` and `takeaways`.
           type: array
           items:
             type: string
@@ -16322,7 +16322,7 @@ components:
             - The default value is `false`.
             - If you define a video language using the `language` parameter, the API uses that language to summarize the video. If you do not define a language, the API detects it based on the video.
         transcriptSummaryAttributes:
-          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes.
+          description: Use this parameter to define the elements of a summary that you want to generate. If you do not define this parameter, the API generates a full summary with all attributes. The possible values are `abstract` and `takeaways`.
           type: array
           items:
             type: string


### PR DESCRIPTION
There is a limitation for Doctave at the moment that blocks the display of enums for a request parameter:

> Looks like we’re only showing the schema defined in items if the schema is an object.

In our case, the schema is for an array. Until Doctave fixes this issue, I've added the enums to the description.