### PR TITLE
Fix example value for summary webhook

### DIFF
--- a/oas_apivideo.yaml
+++ b/oas_apivideo.yaml
@@ -17548,7 +17548,7 @@ x-webhooks:
                 type:
                   type: string
                   description: The name of the webhook event that occurred.
-                  example: video.caption.generated
+                  example: video.summary.generated
                 emittedAt:
                   description: Returns the date-time when the webhook event occurred.
                   type: string


### PR DESCRIPTION
The `video.summary.generated` webhook accidentally had `video.caption.generated` as an example value.